### PR TITLE
added new functionality for flexible grouping constraints, improved iis behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## v4.3.0
+- Added a new tag ``TagRegionToSubsets``, two new parameters ``GroupTotalAnnualMaxCapacity`` and ``GroupTotalAnnualMinCapacity``, as well as two new constraints ``TCC3`` and ``TCC4``. These are fully optional, but allow for flexible creation of aggregated upper and lower bounds for installed capacities.
+- Improved iis handling behavior, especially with the open HiGHS solver.
+- Fixed an issue with old technology names in ramping bounds. 
+
 ## v4.2.0
 - Major performance and memory-efficiency improvements to the model run pipeline (build and results processing). On the Europe test case: total runtime ~-39%, peak RAM ~-39%, results-processing phase ~-94%. The optimization model is unchanged — solver objective values are identical before/after.
 - Results processing: the 6-D `RateOfProductionByTechnologyByMode` and `RateOfUseByTechnologyByMode` containers in `Variable_Parameters` are now sparse `Dict`s instead of dense `DenseAxisArray`s. Downstream code indexing these must use `get(d, key, 0.0)`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GENeSYSMOD"
 uuid = "9f3a37f9-d498-4265-a124-3ae3e9ff3acf"
 authors = ["Dimitri Pinel <dimitri.pinel@sintef.no>", "Lars Hellemo <lars.hellemo@sintef.no>, Konstantin Löffler <kl@wip.tu-berlin.de>"]
-version = "4.2.0"
+version = "4.3.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -24,7 +24,7 @@ DataFrames = "^1.3.4"
 JuMP = "^1.11"
 XLSX = "^0.10.4"
 julia = "^1.12"
-HiGHS = "^1.19"
+HiGHS = "1.19 - 1.22"
 Ipopt = "^1.11"
 DocumenterTools = "^0.1"
 PythonCall = "^0.9.3"

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -9,6 +9,7 @@ Tags - The different tags used in the model to map across sets and subsets
 struct Tags <: InputClass
     TagTechnologyToSubsets::Dict{String,Array{String}}
     TagFuelToSubsets::Dict{String,Array{String}}
+TagRegionToSubsets::Dict{String,Array{String}}
     TagDemandFuelToSector::JuMP.Containers.DenseAxisArray
     TagElectricTechnology::JuMP.Containers.DenseAxisArray
     TagTechnologyToModalType::JuMP.Containers.DenseAxisArray
@@ -320,6 +321,12 @@ struct Parameters <: InputClass
     TotalAnnualMaxCapacity ::JuMP.Containers.DenseAxisArray
     NewCapacityExpansionStop ::JuMP.Containers.DenseAxisArray
     TotalAnnualMinCapacity ::JuMP.Containers.DenseAxisArray
+
+    # Aggregated upper / lower limit on TotalCapacityAnnual summed over a
+    # technology subset × region subset (e.g. all solar in USA). Indexed by
+    # (TechSubset, RegionSubset, Year). Max defaults to 999999 (=no limit).
+    GroupTotalAnnualMaxCapacity ::JuMP.Containers.DenseAxisArray
+    GroupTotalAnnualMinCapacity ::JuMP.Containers.DenseAxisArray
 
     AnnualSectoralEmissionLimit ::JuMP.Containers.DenseAxisArray
 

--- a/src/genesysmod_bounds.jl
+++ b/src/genesysmod_bounds.jl
@@ -323,7 +323,7 @@ function genesysmod_bounds(model,Sets,Params, Vars,Settings,Switch,Maps)
                 Params.ProductionChangeCost[r,t,y] = 0
             end =#
             for l ∈ Sets.Timeslice
-                Params.MinActiveProductionPerTimeslice[y,l,"Power","RES_Hydro_Large",r] = 0.1
+                Params.MinActiveProductionPerTimeslice[y,l,"Power","P_Hydro_Reservoir",r] = 0.1
                 Params.MinActiveProductionPerTimeslice[y,l,"Power","P_Hydro_RoR",r] = 0.05
             end
         end end

--- a/src/genesysmod_dataload.jl
+++ b/src/genesysmod_dataload.jl
@@ -378,6 +378,18 @@ function read_params(in_data, Sets, Switch, Tags)
     TotalAnnualMaxCapacity = create_daa(in_data, "Par_TotalAnnualMaxCapacity", 𝓡, 𝓣, 𝓨)
     NewCapacityExpansionStop = create_daa(in_data, "Par_NewCapacityExpansionStop", 𝓡, 𝓣)
     TotalAnnualMinCapacity = create_daa(in_data, "Par_TotalAnnualMinCapacity", 𝓡, 𝓣, 𝓨)
+
+    # Aggregated capacity limits over (tech subset, region subset, year). Axes
+    # use the keys of the subset dictionaries; empty dataset (no rows) leaves
+    # max at 999999 sentinel (= no limit) and min at 0.
+    𝓣𝓼 = collect(keys(Tags.TagTechnologyToSubsets))
+    𝓡𝓼 = collect(keys(Tags.TagRegionToSubsets))
+    GroupTotalAnnualMaxCapacity = "Par_GroupTotalAnnualMaxCapacity" ∈ XLSX.sheetnames(in_data) ?
+        create_daa_init(in_data, "Par_GroupTotalAnnualMaxCapacity", 999999, 𝓣𝓼, 𝓡𝓼, 𝓨) :
+        DenseArray(fill(999999.0, length(𝓣𝓼), length(𝓡𝓼), length(𝓨)), 𝓣𝓼, 𝓡𝓼, 𝓨)
+    GroupTotalAnnualMinCapacity = "Par_GroupTotalAnnualMinCapacity" ∈ XLSX.sheetnames(in_data) ?
+        create_daa(in_data, "Par_GroupTotalAnnualMinCapacity", 𝓣𝓼, 𝓡𝓼, 𝓨) :
+        DenseArray(zeros(length(𝓣𝓼), length(𝓡𝓼), length(𝓨)), 𝓣𝓼, 𝓡𝓼, 𝓨)
     TotalTechnologyAnnualActivityUpperLimit = create_daa(in_data, "Par_TotalAnnualMaxActivity", 𝓡, 𝓣, 𝓨)
     TotalTechnologyAnnualActivityLowerLimit = create_daa(in_data, "Par_TotalAnnualMinActivity", 𝓡, 𝓣, 𝓨)
     TotalTechnologyModelPeriodActivityUpperLimit = create_daa_init(in_data, "Par_ModelPeriodActivityMaxLimit", 999999, 𝓡, 𝓣)

--- a/src/genesysmod_dataload.jl
+++ b/src/genesysmod_dataload.jl
@@ -198,6 +198,8 @@ function read_tags(in_data, Sets, Switch, s_infeas, s_dispatch)
 
     TagTechnologyToSubsets = read_subsets(in_data, "Par_TagTechnologyToSubsets") #TODO handle the tags consistently: now we have lists of technology in one and DAA of tech, subsets and 1. Some parameters seems also redundant.
     TagFuelToSubsets = read_subsets(in_data, "Par_TagFuelToSubsets")
+TagRegionToSubsets = "Par_TagRegionToSubsets" ∈ XLSX.sheetnames(in_data) ?
+        read_subsets(in_data, "Par_TagRegionToSubsets") : Dict{String,Array{String}}()
     TagDemandFuelToSector = create_daa(in_data, "Par_TagDemandFuelToSector", 𝓕, 𝓢𝓮)
     TagElectricTechnology = create_daa(in_data, "Par_TagElectricTechnology", 𝓣)
     TagTechnologyToModalType = create_daa(in_data, "Par_TagTechnologyToModalType", 𝓣, 𝓜, 𝓜𝓽)
@@ -209,7 +211,7 @@ function read_tags(in_data, Sets, Switch, s_infeas, s_dispatch)
     TagModalTypeToModalGroups = create_daa(in_data, "Par_TagModalTypeToModalGroups", 𝓜𝓽, ["TransportModes","ModalSubgroups"])
     TagCanFuelBeTraded = create_daa(in_data, "Par_TagCanFuelBeTraded", 𝓕)
 
-    tags = Tags(TagTechnologyToSubsets,TagFuelToSubsets,TagDemandFuelToSector,TagElectricTechnology,
+    tags = Tags(TagTechnologyToSubsets,TagFuelToSubsets,TagRegionToSubsets,TagDemandFuelToSector,TagElectricTechnology,
     TagTechnologyToModalType,TagTechnologyToSector,RETagTechnology,RETagFuel,TagDispatchableTechnology,
     TagModalTypeToModalGroups,TagCanFuelBeTraded)
 
@@ -434,8 +436,8 @@ function read_params(in_data, Sets, Switch, Tags)
         ProductionChangeCost = create_daa(in_data, "Par_ProductionChangeCost",𝓣,𝓨)
         MinActiveProductionPerTimeslice = DenseArray(zeros(length(𝓨), length(𝓛), length(𝓕), length(𝓣), length(𝓡)), 𝓨, 𝓛, 𝓕, 𝓣, 𝓡)
 
-        MinActiveProductionPerTimeslice[:,:,"Power","RES_Hydro_Large",:] .= 0.1
-        MinActiveProductionPerTimeslice[:,:,"Power","RES_Hydro_Small",:] .= 0.05
+        MinActiveProductionPerTimeslice[:,:,"Power","P_Hydro_Reservoir",:] .= 0.1
+        MinActiveProductionPerTimeslice[:,:,"Power","P_Hydro_RoR",:] .= 0.05
     else
         RampingUpFactor = nothing
         RampingDownFactor = nothing
@@ -488,6 +490,7 @@ function read_params(in_data, Sets, Switch, Tags)
     StorageLevelStart,MinStorageCharge,
     OperationalLifeStorage,CapitalCostStorage,ResidualStorageCapacity,TechnologyToStorage,
     TechnologyFromStorage,StorageMaxCapacity,TotalAnnualMaxCapacity, NewCapacityExpansionStop,TotalAnnualMinCapacity,
+GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,
     AnnualSectoralEmissionLimit,TotalAnnualMaxCapacityInvestment,
     TotalAnnualMinCapacityInvestment,TotalTechnologyAnnualActivityUpperLimit,
     TotalTechnologyAnnualActivityLowerLimit, TotalTechnologyModelPeriodActivityUpperLimit,
@@ -590,6 +593,11 @@ function get_aggregate_params(Params_Full, Sets, Sets_full)
     NewCapacityExpansionStop = JuMP.Containers.DenseAxisArray(zeros(length(𝓡),length(𝓣)), 𝓡, 𝓣)
 
     TotalAnnualMinCapacity = aggregate_daa(Params_Full.TotalAnnualMinCapacity, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
+# Group capacity limits — dispatch path: dataset-defined subset axes don't change with
+    # region slicing, so just slice the year dimension (subsets stay; sub-region totals will
+    # be checked against the same group limits as the full model).
+    GroupTotalAnnualMaxCapacity = Params_Full.GroupTotalAnnualMaxCapacity[:,:,𝓨]
+    GroupTotalAnnualMinCapacity = Params_Full.GroupTotalAnnualMinCapacity[:,:,𝓨]
     TotalTechnologyAnnualActivityUpperLimit = aggregate_daa(Params_Full.TotalTechnologyAnnualActivityUpperLimit, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
     TotalTechnologyAnnualActivityLowerLimit = aggregate_daa(Params_Full.TotalTechnologyAnnualActivityLowerLimit, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
     TotalTechnologyModelPeriodActivityUpperLimit = aggregate_daa(Params_Full.TotalTechnologyModelPeriodActivityUpperLimit, 𝓡, 𝓡_full, Sum(), 𝓣)
@@ -663,6 +671,7 @@ function get_aggregate_params(Params_Full, Sets, Sets_full)
     OperationalLifeStorage,CapitalCostStorage,ResidualStorageCapacity,TechnologyToStorage,
     TechnologyFromStorage,StorageMaxCapacity,TotalAnnualMaxCapacity,
     NewCapacityExpansionStop,TotalAnnualMinCapacity,
+GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,
     AnnualSectoralEmissionLimit,TotalAnnualMaxCapacityInvestment,
     TotalAnnualMinCapacityInvestment,TotalTechnologyAnnualActivityUpperLimit,
     TotalTechnologyAnnualActivityLowerLimit, TotalTechnologyModelPeriodActivityUpperLimit,

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -818,6 +818,33 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
       @constraint(model, Vars.TotalCapacityAnnual[y,t,r] >= Params.TotalAnnualMinCapacity[r,t,y], base_name="TCC2_TotalAnnualMinCapacityConstraint|$(y)|$(t)|$(r)")
     end
   end end end
+
+  # TCC3 / TCC4: aggregated upper / lower limit on TotalCapacityAnnual summed
+  # over a technology subset (Tags.TagTechnologyToSubsets) intersected with a
+  # region subset (Tags.TagRegionToSubsets), per year. Use 999999 sentinel for
+  # "no upper limit" (matches TCC1 convention); 0 lower limit is inert.
+  for ts ∈ keys(Params.Tags.TagTechnologyToSubsets)
+    techs_in_subset = intersect(Params.Tags.TagTechnologyToSubsets[ts], 𝓣)
+    isempty(techs_in_subset) && continue
+    for rs ∈ keys(Params.Tags.TagRegionToSubsets)
+      regs_in_subset = intersect(Params.Tags.TagRegionToSubsets[rs], 𝓡)
+      isempty(regs_in_subset) && continue
+      for y ∈ 𝓨
+        if Params.GroupTotalAnnualMaxCapacity[ts,rs,y] < 999999
+          @constraint(model,
+            sum(Vars.TotalCapacityAnnual[y,t,r] for t ∈ techs_in_subset for r ∈ regs_in_subset)
+              <= Params.GroupTotalAnnualMaxCapacity[ts,rs,y],
+            base_name="TCC3_GroupMaxCapacityConstraint|$(y)|$(ts)|$(rs)")
+        end
+        if Params.GroupTotalAnnualMinCapacity[ts,rs,y] > 0
+          @constraint(model,
+            sum(Vars.TotalCapacityAnnual[y,t,r] for t ∈ techs_in_subset for r ∈ regs_in_subset)
+              >= Params.GroupTotalAnnualMinCapacity[ts,rs,y],
+            base_name="TCC4_GroupMinCapacityConstraint|$(y)|$(ts)|$(rs)")
+        end
+      end
+    end
+  end
   print("Cstr: Tot. Cap. : ",Dates.now()-start,"\n")
 
   ############### New Capacity Constraints ##############

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -823,11 +823,11 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
   # over a technology subset (Tags.TagTechnologyToSubsets) intersected with a
   # region subset (Tags.TagRegionToSubsets), per year. Use 999999 sentinel for
   # "no upper limit" (matches TCC1 convention); 0 lower limit is inert.
-  for ts ∈ keys(Params.Tags.TagTechnologyToSubsets)
-    techs_in_subset = intersect(Params.Tags.TagTechnologyToSubsets[ts], 𝓣)
+  for (ts, techs) ∈ Params.Tags.TagTechnologyToSubsets
+    techs_in_subset = intersect(techs, 𝓣)
     isempty(techs_in_subset) && continue
-    for rs ∈ keys(Params.Tags.TagRegionToSubsets)
-      regs_in_subset = intersect(Params.Tags.TagRegionToSubsets[rs], 𝓡)
+    for (rs, regs) ∈ Params.Tags.TagRegionToSubsets
+      regs_in_subset = intersect(regs, 𝓡)
       isempty(regs_in_subset) && continue
       for y ∈ 𝓨
         if Params.GroupTotalAnnualMaxCapacity[ts,rs,y] < 999999

--- a/src/genesysmod_main.jl
+++ b/src/genesysmod_main.jl
@@ -229,7 +229,12 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
     elseif solver_name(model) == "HiGHS"
         set_optimizer_attribute(model, "solver", "ipm")
         #set_optimizer_attribute(model, "solver", "pdlp")
-        set_optimizer_attribute(model, "run_crossover", "off")
+        set_optimizer_attribute(model, "run_crossover", "on")
+        # IIS strategy: bit2 (elastic IS) | bit8 (true IIS) = 10. Set here,
+        # pre-solve, so it never dirties the model after optimize!. Consumed by
+        # HiGHS native IIS; the MathOptIIS fallback used by current HiGHS.jl
+        # ignores it, but it is harmless and future-proofs the native path.
+        set_optimizer_attribute(model, "iis_strategy", 10)
         if solver_log
             set_optimizer_attribute(model, "log_file", joinpath(resultdir,"Run_$(elmod_nthhour)_$(today()).log"))
         end
@@ -258,20 +263,20 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
     #
     if occursin("INFEASIBLE",string(termination_status(model)))
         if switch_iis == 1
-            if occursin("Gurobi",string(solver)) || occursin("CPLEX",string(solver))
-                println("Termination status:", termination_status(model), ". Computing IIS")
+                            println("Termination status:", termination_status(model), ". Computing IIS")
                 compute_conflict!(model)
+# MathOptIIS (what current HiGHS.jl uses for compute_conflict!)
+            # modifies the model internally while running its elastic filter, so
+            # JuMP flags the model "modified since optimize!" and a normal
+            # get_attribute(model, ConflictStatus()) throws OptimizeNotCalled.
+            # Query the MOI backend directly to bypass that guard. This path also
+            # works for Gurobi/CPLEX native IIS, so all solvers share it.
+            cstatus = MOI.get(JuMP.backend(model), MOI.ConflictStatus())
+            if cstatus == MOI.CONFLICT_FOUND
                 println("Saving IIS to file")
-                print_iis(model)
-            elseif occursin("HiGHS",string(solver))
-                println("Termination status:", termination_status(model), ". Printing violations:")
-                res = violations(model)
-                println("Saving violations to file")
-                open(joinpath(resultdir,"IIS_$(elmod_nthhour)_$(today()).txt"), "w") do f
-                    for line in res
-                        println(f, line)
-                    end
-                end
+                print_iis(model; filename=joinpath(resultdir,"IIS_$(elmod_nthhour)_$(today())"))
+            else
+                        println("No conflict found: ", cstatus)
             end
         else
             error("Model infeasible. Turn on 'switch_iis' to compute and write the iis file")

--- a/src/genesysmod_main.jl
+++ b/src/genesysmod_main.jl
@@ -264,19 +264,36 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
     if occursin("INFEASIBLE",string(termination_status(model)))
         if switch_iis == 1
                             println("Termination status:", termination_status(model), ". Computing IIS")
-                compute_conflict!(model)
+            try
 # MathOptIIS (what current HiGHS.jl uses for compute_conflict!)
             # modifies the model internally while running its elastic filter, so
             # JuMP flags the model "modified since optimize!" and a normal
             # get_attribute(model, ConflictStatus()) throws OptimizeNotCalled.
-            # Query the MOI backend directly to bypass that guard. This path also
-            # works for Gurobi/CPLEX native IIS, so all solvers share it.
+                # Query the MOI backend directly to bypass that guard. This path
+                # also works for Gurobi/CPLEX native IIS, so all solvers share it.
+                compute_conflict!(model)
             cstatus = MOI.get(JuMP.backend(model), MOI.ConflictStatus())
             if cstatus == MOI.CONFLICT_FOUND
                 println("Saving IIS to file")
                 print_iis(model; filename=joinpath(resultdir,"IIS_$(elmod_nthhour)_$(today())"))
             else
                         println("No conflict found: ", cstatus)
+                end
+            catch e
+                # Older HiGHS.jl (< 1.19) does not expose MathOptIIS, so the
+                # call above errors. Fall back to the legacy `violations`
+                # writer for HiGHS. Any other solver should surface the error.
+                if occursin("HiGHS", string(solver))
+                    println("IIS query failed ($(typeof(e).name.name)) — falling back to violations writer.")
+                    res = violations(model)
+                    open(joinpath(resultdir,"IIS_$(elmod_nthhour)_$(today()).txt"), "w") do f
+                        for line in res
+                            println(f, line)
+                        end
+                    end
+                else
+                    rethrow(e)
+                end
             end
         else
             error("Model infeasible. Turn on 'switch_iis' to compute and write the iis file")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -401,10 +401,15 @@ directory and is named iis.txt. The function compute_conflict!(model) must be ru
 The iis contains the set of constraint causing the infeasibility.
 """
 function print_iis(model;filename="iis")
+    # Query per-constraint conflict status from the MOI backend rather than via
+    # get_attribute(con, ...). MathOptIIS leaves the model flagged "modified
+    # since optimize!", which makes the JuMP-level query throw OptimizeNotCalled.
+    # The backend (a CachingOptimizer) maps indices and skips that guard.
+    b = JuMP.backend(model)
     list_of_conflicting_constraints = ConstraintRef[]
     for (F, S) in list_of_constraint_types(model)
         for con in all_constraints(model, F, S)
-            if get_attribute(con, MOI.ConstraintConflictStatus()) == MOI.IN_CONFLICT
+            if MOI.get(b, MOI.ConstraintConflictStatus(), JuMP.index(con)) == MOI.IN_CONFLICT
                 push!(list_of_conflicting_constraints, con)
             end
         end
@@ -415,6 +420,7 @@ function print_iis(model;filename="iis")
             write(file, string(r)*"\n")
         end
     end
+    return list_of_conflicting_constraints
 end
 
 """

--- a/test/test_fetchdata.jl
+++ b/test/test_fetchdata.jl
@@ -17,7 +17,7 @@ end
         @test sum([startswith(file,"Timeseries") for file in files]) == 1
     end
     @testset "Specific older version and dataset" begin
-        fetch_data_release(;version_tag="v1.0.4", dataset_name="Europe_EnVis_Green", dest_dir=TEST_RESULTS_DIR)
+        fetch_data_release(;version_tag="v1.1.0", dataset_name="Europe_EnVis_Green", dest_dir=TEST_RESULTS_DIR)
         files = readdir(TEST_RESULTS_DIR)
         @test sum([startswith(file,"RegularParameters_Europe_EnVis_Green") for file in files]) == 1
         @test sum([startswith(file,"Timeseries_Europe_EnVis_Green") for file in files]) == 1


### PR DESCRIPTION
# 📌 Pull Request Summary

Introduces a new functionality (see below) to define flexible constraints for installed capacity across technology and region groups. Improves infeasibility-finding behavior, and fixes a minor bug in rarely used code. Closely related to https://github.com/GENeSYS-MOD/GENeSYS_MOD.data/pull/49

## 🔗 Related Issue(s)

N/A

## 🛠️ Changes Introduced

Two major changes and one minor:
 1. **Major**: Introduces GroupTotalAnnualMaxCapacity and GroupTotalAnnualMinCapacity, together with a TagRegionToSubsets tag. This allows for flexible definition of new TotalCapacity constraints (TCC3 & TCC4) that can be used to limit the TotalCapacity of any flexibly defined regional and/or technology subset. This could e.g. be across technologies (subset Solar, region DE), across regions (region-subset Central Europe, technology subset Nuclear), or both (by defining both a new region subset and a new technology subset).
 2. Major: improved IIS handling behavior, especially with HiGHS, to dig deeper if the model goes infeasible in presolve directly.
 3. Minor: fixed a bug with old technology labels in the bounds for the ramping constraints.

**Note:** the code in this PR will most likely fail since it is reliant on the PR in the data repo that is linked. https://github.com/GENeSYS-MOD/GENeSYS_MOD.data/pull/49

## 📋 Checklist

- [x] Code follows project conventions
- [x] Tests have been added/updated (if needed)
- [x] Documentation has been updated (if applicable)
- [x] Relevant issues linked
- [x] NEWS.md updated
- [x] Version number increase applied (if planned for release)
- [x] Reviewers assigned
