### PR TITLE
Minor improvements (robustness, matrix conditioning, bugfixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,40 @@ It reads scenario data from Excel, builds a large LP, solves it
 - `genesysmod_bounds.jl`, `genesysmod_settings.jl` — bounds and run settings.
 - `genesysmod_variable_parameter.jl`, `genesysmod_results.jl`,
   `genesysmod_results_raw.jl` — post-solve result processing.
+- `genesysmod_db.jl` — DuckDB result + input-data databases (writers, `Scenario`
+  keying, handle release/retry).
+- `genesysmod_errorcheck.jl` — input-data validation (port of
+  `genesysmod_errorcheck.gms`).
 - `datastructures.jl` — `Sets`, `Parameters`, `Variables`, `Maps`, `Settings`,
   `Variable_Parameters` structs.
 - `utils.jl` — `create_daa` (builds parameter `DenseAxisArray`s),
   `convert_jump_container_to_df`.
+
+## Outputs, databases & input checks
+
+- **Result CSVs** are written when `switch_processed_results = 1`. Processed
+  outputs are rounded to 4 digits (GAMS parity).
+- **DuckDB results database** (`switch_results_db = 1`): all outputs go to
+  `genesysmod_results_db.duckdb` in `resultdir` — processed tables (`output_*`),
+  raw variables (`raw_*`), `Variable_Parameters` intermediates (`varpar_*`) and
+  selected duals (`duals_*`). Every table carries a `Scenario` column
+  (= `extr_str_results`): re-running a scenario first purges its rows from every
+  table, a new scenario name appends. Independent of the CSV switch.
+- **Run configuration** is recorded with the results: every `Switch` field is
+  written to an `output_switches` table/CSV, so a run's exact setup travels with
+  its outputs.
+- **Input-data database**: `switch_test_data_load = 1` dumps the fully processed
+  input parameters to `genesysmod_inputdata_db.duckdb` (one table per parameter
+  and per set, real dimension names, `Params.Tags` included) and stops before the
+  solve; `switch_dump_input_data = 1` writes the same dump and continues.
+- Raw dumps and DB tables use **real dimension names** (Region, Technology, Fuel,
+  Year, …), not `x1..xN`.
+- DB handles are released at run end (`release_dbs()`, exported); a write blocked
+  by an external reader holding the file is queued and flushed via
+  `retry_db_writes()` (exported) rather than crashing the run.
+- **Input-data checks** (`genesysmod_errorcheck.jl`, run after bounds /
+  scenario data): `switch_errorcheck` — `0` skip, `1` report-only, `2` (default)
+  abort on hard checks. Full offender lists go to `Errorcheck_<nthhour>_<date>.txt`.
 
 ## Conventions & gotchas
 
@@ -53,6 +83,9 @@ It reads scenario data from Excel, builds a large LP, solves it
 - Code uses Unicode set aliases: `𝓨` year, `𝓡` region, `𝓣` technology,
   `𝓕` fuel, `𝓜` mode, `𝓛` timeslice, `𝓢` storage, `𝓔` emission. 2-space indent
   inside functions.
+- `switch_endogenous_specifieddemandforecasting` (default 1) forecasts later-year
+  demand from the base year via `SpecifiedDemandDevelopment`; set 0 to use the
+  per-year values in `Par_SpecifiedAnnualDemand` directly.
 
 ## Performance
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,27 @@
 Release Notes
 =============
 
+## v4.4.1
+- Emission-limit constraints (E8/E9/E10/E13) are only generated when a real limit is
+  set (`< 999999`) instead of always adding a toothless `<= ~1e6` row; dual lookups
+  for these limits (endogenous CO2 price, `CarbonPrice`) return 0 when the constraint
+  is absent instead of erroring.
+- Results (and dispatch) are written on any feasible primal solution
+  (`primal_status == FEASIBLE_POINT`), not only a certified `OPTIMAL` — a
+  crossover-free barrier solution is no longer silently dropped.
+- `TagTimeIndependentFuel` is now read from the input data
+  (`Par_TagTimeIndependentFuel` sheet) instead of a hard-coded fuel list.
+- Base-year debug slack variables (`BaseYearBounds_*`, `HeatingSlack`) are only built
+  when `switch_base_year_bounds_debugging == 1` (leaner production LP); the BigM
+  penalty is lowered 9999 → 1000.
+- Group capacity limits (TCC3/TCC4) are only built on the investment path; ramping
+  limits are scaled by `elmod_hourstep`; `CapacityFactor` values below 0.01 are zeroed
+  after timeseries reduction; Gurobi runs with `NumericFocus=1` and `ScaleFlag=2`.
+- The input-data database dump now also includes `Params.Tags`.
+- Fixes: `df_total_capacity` no longer drops technologies via a stray subset;
+  `read_emissions` reads `AnnualEmissions_*.csv` (was the storage-capacity file); the
+  empty-trade dummy uses an existing fuel; empty per-technology sums use `init=0.0`.
+
 ## v4.4.0
 - **DuckDB result + input databases.** With `switch_results_db = 1`, all outputs
   (processed result tables, raw variables, `Variable_Parameters` intermediates) are

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ Release Notes
 - Fixes: `df_total_capacity` no longer drops technologies via a stray subset;
   `read_emissions` reads `AnnualEmissions_*.csv` (was the storage-capacity file); the
   empty-trade dummy uses an existing fuel; empty per-technology sums use `init=0.0`.
+- HiGHS compatibility set to `1.19 - 1.22` (previously `1.22`).
 
 ## v4.4.0
 - **DuckDB result + input databases.** With `switch_results_db = 1`, all outputs

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GENeSYSMOD"
 uuid = "9f3a37f9-d498-4265-a124-3ae3e9ff3acf"
-version = "4.4.0"
+version = "4.4.1"
 authors = ["Dimitri Pinel <dimitri.pinel@sintef.no>", "Lars Hellemo <lars.hellemo@sintef.no>, Konstantin Löffler <kl@wip.tu-berlin.de>"]
 
 [deps]

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -328,6 +328,11 @@ struct Parameters <: InputClass
     GroupTotalAnnualMaxCapacity ::JuMP.Containers.DenseAxisArray
     GroupTotalAnnualMinCapacity ::JuMP.Containers.DenseAxisArray
 
+    # Per-fuel time-independence tag read from Par_TagTimeIndependentFuel (Fuel, Value);
+    # 1 = the fuel balance is enforced annually rather than per timeslice. Fuels not
+    # listed default to 0 (the derived base in genesysmod_equ still applies on top).
+    TagTimeIndependentFuel ::JuMP.Containers.DenseAxisArray
+
     AnnualSectoralEmissionLimit ::JuMP.Containers.DenseAxisArray
 
     TotalAnnualMaxCapacityInvestment ::JuMP.Containers.DenseAxisArray

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -486,9 +486,9 @@ struct Variables
 
     RateOfTotalActivity ::Union{Nothing,VarDenseIISS}
 
-    BaseYearBounds_TooLow ::JuMP.Containers.SparseAxisArray{VariableRef, 4, Tuple{String, String, String, Int}}
-    BaseYearBounds_TooHigh ::JuMP.Containers.SparseAxisArray{VariableRef, 4, Tuple{String, String, String, Int}}
-    HeatingSlack ::VarDenseSI
+    BaseYearBounds_TooLow ::Union{Nothing, JuMP.Containers.SparseAxisArray{VariableRef, 4, Tuple{String, String, String, Int}}}
+    BaseYearBounds_TooHigh ::Union{Nothing, JuMP.Containers.SparseAxisArray{VariableRef, 4, Tuple{String, String, String, Int}}}
+    HeatingSlack ::Union{Nothing, VarDenseSI}
 
     DiscountedSalvageValueTransmission ::VarDenseIS
 

--- a/src/genesysmod_dataload.jl
+++ b/src/genesysmod_dataload.jl
@@ -428,6 +428,10 @@ function read_params(in_data, Sets, Switch, Tags)
     GroupTotalAnnualMinCapacity = "Par_GroupTotalAnnualMinCapacity" ∈ XLSX.sheetnames(in_data) ?
         create_daa(in_data, "Par_GroupTotalAnnualMinCapacity", 𝓣𝓼, 𝓡𝓼, 𝓨) :
         DenseArray(zeros(length(𝓣𝓼), length(𝓡𝓼), length(𝓨)), 𝓣𝓼, 𝓡𝓼, 𝓨)
+    # Per-fuel time-independence tag (Fuel, Value). Optional sheet; absent => all 0.
+    TagTimeIndependentFuel = "Par_TagTimeIndependentFuel" ∈ XLSX.sheetnames(in_data) ?
+        create_daa(in_data, "Par_TagTimeIndependentFuel", 𝓕) :
+        DenseArray(zeros(length(𝓕)), 𝓕)
     TotalTechnologyAnnualActivityUpperLimit = create_daa(in_data, "Par_TotalAnnualMaxActivity", 𝓡, 𝓣, 𝓨)
     TotalTechnologyAnnualActivityLowerLimit = create_daa(in_data, "Par_TotalAnnualMinActivity", 𝓡, 𝓣, 𝓨)
     TotalTechnologyModelPeriodActivityUpperLimit = create_daa_init(in_data, "Par_ModelPeriodActivityMaxLimit", 999999, 𝓡, 𝓣)
@@ -541,6 +545,7 @@ function read_params(in_data, Sets, Switch, Tags)
     OperationalLifeStorage,CapitalCostStorage,ResidualStorageCapacity,TechnologyToStorage,
     TechnologyFromStorage,StorageMaxCapacity,TotalAnnualMaxCapacity, NewCapacityExpansionStop,TotalAnnualMinCapacity,
     GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,
+    TagTimeIndependentFuel,
     AnnualSectoralEmissionLimit,TotalAnnualMaxCapacityInvestment,
     TotalAnnualMinCapacityInvestment,TotalTechnologyAnnualActivityUpperLimit,
     TotalTechnologyAnnualActivityLowerLimit, TotalTechnologyModelPeriodActivityUpperLimit,
@@ -648,6 +653,7 @@ function get_aggregate_params(Params_Full, Sets, Sets_full)
     # be checked against the same group limits as the full model).
     GroupTotalAnnualMaxCapacity = Params_Full.GroupTotalAnnualMaxCapacity[:,:,𝓨]
     GroupTotalAnnualMinCapacity = Params_Full.GroupTotalAnnualMinCapacity[:,:,𝓨]
+    TagTimeIndependentFuel = Params_Full.TagTimeIndependentFuel
     TotalTechnologyAnnualActivityUpperLimit = aggregate_daa(Params_Full.TotalTechnologyAnnualActivityUpperLimit, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
     TotalTechnologyAnnualActivityLowerLimit = aggregate_daa(Params_Full.TotalTechnologyAnnualActivityLowerLimit, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
     TotalTechnologyModelPeriodActivityUpperLimit = aggregate_daa(Params_Full.TotalTechnologyModelPeriodActivityUpperLimit, 𝓡, 𝓡_full, Sum(), 𝓣)
@@ -722,6 +728,7 @@ function get_aggregate_params(Params_Full, Sets, Sets_full)
     TechnologyFromStorage,StorageMaxCapacity,TotalAnnualMaxCapacity,
     NewCapacityExpansionStop,TotalAnnualMinCapacity,
     GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,
+    TagTimeIndependentFuel,
     AnnualSectoralEmissionLimit,TotalAnnualMaxCapacityInvestment,
     TotalAnnualMinCapacityInvestment,TotalTechnologyAnnualActivityUpperLimit,
     TotalTechnologyAnnualActivityLowerLimit, TotalTechnologyModelPeriodActivityUpperLimit,

--- a/src/genesysmod_dataload.jl
+++ b/src/genesysmod_dataload.jl
@@ -428,10 +428,8 @@ function read_params(in_data, Sets, Switch, Tags)
     GroupTotalAnnualMinCapacity = "Par_GroupTotalAnnualMinCapacity" ∈ XLSX.sheetnames(in_data) ?
         create_daa(in_data, "Par_GroupTotalAnnualMinCapacity", 𝓣𝓼, 𝓡𝓼, 𝓨) :
         DenseArray(zeros(length(𝓣𝓼), length(𝓡𝓼), length(𝓨)), 𝓣𝓼, 𝓡𝓼, 𝓨)
-    # Per-fuel time-independence tag (Fuel, Value). Optional sheet; absent => all 0.
-    TagTimeIndependentFuel = "Par_TagTimeIndependentFuel" ∈ XLSX.sheetnames(in_data) ?
-        create_daa(in_data, "Par_TagTimeIndependentFuel", 𝓕) :
-        DenseArray(zeros(length(𝓕)), 𝓕)
+    # Per-fuel time-independence tag (Fuel, Value); a standard input sheet like the other tags.
+    TagTimeIndependentFuel = create_daa(in_data, "Par_TagTimeIndependentFuel", 𝓕)
     TotalTechnologyAnnualActivityUpperLimit = create_daa(in_data, "Par_TotalAnnualMaxActivity", 𝓡, 𝓣, 𝓨)
     TotalTechnologyAnnualActivityLowerLimit = create_daa(in_data, "Par_TotalAnnualMinActivity", 𝓡, 𝓣, 𝓨)
     TotalTechnologyModelPeriodActivityUpperLimit = create_daa_init(in_data, "Par_ModelPeriodActivityMaxLimit", 999999, 𝓡, 𝓣)

--- a/src/genesysmod_db.jl
+++ b/src/genesysmod_db.jl
@@ -390,6 +390,33 @@ function dump_inputs_db(case, switch::Switch)
             @warn "Could not dump parameter $(field)" exception=e
         end
     end
+    # Tags (Params.Tags): DenseAxisArray tags via the same rowtable path; the
+    # Dict tags (Tag*ToSubsets) expanded to (Subset, Element) rows.
+    if hasproperty(Params, :Tags)
+        for tf in fieldnames(typeof(Params.Tags))
+            tag = getfield(Params.Tags, tf)
+            try
+                if tag isa JuMP.Containers.DenseAxisArray
+                    df = DataFrame(JuMP.Containers.rowtable(identity, tag; header=_rowtable_header(tag, tf, Sets)))
+                elseif tag isa AbstractDict
+                    df = DataFrame(Subset=String[], Element=String[])
+                    for (k, vs) in tag, v in vs
+                        push!(df, (string(k), string(v)))
+                    end
+                else
+                    continue
+                end
+                isempty(df) && continue
+                reg = "df_tag"
+                DuckDB.register_data_frame(con, df, reg)
+                DBInterface.execute(con, "CREATE TABLE $(_quote_ident(string(tf))) AS SELECT * FROM $(_quote_ident(reg))")
+                DuckDB.unregister_data_frame(con, reg)
+                ntables += 1
+            catch e
+                @warn "Could not dump tag $(tf)" exception=e
+            end
+        end
+    end
     for field in fieldnames(typeof(Sets))
         s = getfield(Sets, field)
         s isa AbstractVector || continue

--- a/src/genesysmod_dec.jl
+++ b/src/genesysmod_dec.jl
@@ -176,16 +176,17 @@ function genesysmod_dec(model,Sets, Params,Switch, Maps)
         RateOfTotalActivity=nothing
     end
 
-    BaseYearBounds_TooLow = @variable(model, BaseYearBounds_TooLow[r=𝓡, t=𝓣, f=𝓕, y=𝓨; (t,f) ∈ Maps.Set_Tech_FuelOut] >= 0)
-    BaseYearBounds_TooHigh = @variable(model, BaseYearBounds_TooHigh[r=𝓡, t=𝓣, f=𝓕, y=𝓨; (t,f) ∈ Maps.Set_Tech_FuelOut] >= 0)
-    if Switch.switch_base_year_bounds_debugging == 0
-        for y ∈ 𝓨 for r ∈ 𝓡 for (t,f) ∈ Maps.Set_Tech_FuelOut
-            JuMP.fix(BaseYearBounds_TooLow[r,t,f,y], 0;force=true)
-            JuMP.fix(BaseYearBounds_TooHigh[r,t,f,y], 0;force=true)
-        end end end
+    # Debug-only slack variables: only declared when switch_base_year_bounds_debugging == 1.
+    # Production runs skip them entirely (lean LP, no BigM penalty rows, no fix-to-0 vars).
+    if Switch.switch_base_year_bounds_debugging == 1
+        BaseYearBounds_TooLow  = @variable(model, BaseYearBounds_TooLow[r=𝓡, t=𝓣, f=𝓕, y=𝓨; (t,f) ∈ Maps.Set_Tech_FuelOut] >= 0)
+        BaseYearBounds_TooHigh = @variable(model, BaseYearBounds_TooHigh[r=𝓡, t=𝓣, f=𝓕, y=𝓨; (t,f) ∈ Maps.Set_Tech_FuelOut] >= 0)
+        HeatingSlack           = @variable(model, HeatingSlack[𝓡, 𝓨] >= 0, container=DenseArray)
+    else
+        BaseYearBounds_TooLow  = nothing
+        BaseYearBounds_TooHigh = nothing
+        HeatingSlack           = nothing
     end
-
-    HeatingSlack= @variable(model, HeatingSlack[𝓡, 𝓨] >= 0, container=DenseArray)
 
     DiscountedSalvageValueTransmission= @variable(model, DiscountedSalvageValueTransmission[𝓨,𝓡] >= 0, container=DenseArray)
 

--- a/src/genesysmod_dec.jl
+++ b/src/genesysmod_dec.jl
@@ -128,7 +128,10 @@ function genesysmod_dec(model,Sets, Params,Switch, Maps)
 
 
     ######### Trade #############
-    imp_exp_sets = isempty(Maps.Set_Fuel_Regions) ? Set([(String("ETS"),String(𝓡[1]),String(𝓡[1]))]) : Maps.Set_Fuel_Regions # dummy to avoid type problems in dispatch if se is empty
+    # Dummy self-trade entry keeps the sparse trade variables typed when the trade set
+    # is empty. Uses 𝓕[1] (always present); the old "ETS" placeholder is absent in
+    # reduced datasets, so no index matched and the container stayed {Any}.
+    imp_exp_sets = isempty(Maps.Set_Fuel_Regions) ? Set([(String(𝓕[1]),String(𝓡[1]),String(𝓡[1]))]) : Maps.Set_Fuel_Regions
     Import = @variable(model, Import[y=𝓨, l=𝓛, f=𝓕, r1=𝓡, r2=𝓡; (f,r1,r2) ∈ imp_exp_sets] >= 0)
     Export = @variable(model, Export[y=𝓨, l=𝓛, f=𝓕, r1=𝓡, r2=𝓡; (f,r1,r2) ∈ imp_exp_sets] >= 0)
     NewTradeCapacity = @variable(model, NewTradeCapacity[y=𝓨, f=𝓕, r1=𝓡, r2=𝓡; (f,r1,r2) ∈ imp_exp_sets] >= 0)

--- a/src/genesysmod_dispatch.jl
+++ b/src/genesysmod_dispatch.jl
@@ -526,7 +526,7 @@ function read_emissions(Sets, Switch, region_full, s_rawresults::CSVResult)
 end
 
 function read_emissions(Sets, Switch, s_rawresults::CSVResult)
-    in_data=CSV.read(joinpath(Switch.resultdir[], "TotalStorageCapacityAnnual_" * Switch.model_region * "_" * Switch.emissionPathway * "_" * Switch.emissionScenario * "_" *Switch.extr_str_results * ".csv"), DataFrame)
+    in_data=CSV.read(joinpath(Switch.resultdir[], "AnnualEmissions_" * Switch.model_region * "_" * Switch.emissionPathway * "_" * Switch.emissionScenario * "_" *Switch.extr_str_results * ".csv"), DataFrame)
     tmp_AnnualEmissions = create_daa(in_data, "", Sets.Year, Sets.Emission, Sets.Region_full)
     return tmp_AnnualEmissions
 end

--- a/src/genesysmod_dispatch.jl
+++ b/src/genesysmod_dispatch.jl
@@ -276,7 +276,9 @@ function genesysmod_dispatch(;elmod_nthhour = 1, elmod_starthour = 1, solver, DN
             error("Model infeasible. Turn on 'switch_iis' to compute and write the iis file")
         end
 
-    elseif termination_status(model) == MOI.OPTIMAL
+    elseif primal_status(model) == MOI.FEASIBLE_POINT   # feasible (incl. sub-optimal barrier), not only certified OPTIMAL
+        termination_status(model) == MOI.OPTIMAL ||
+            @warn "Solver did not certify optimality ($(termination_status(model))); writing dispatch results from the feasible solution."
         VarPar = genesysmod_variable_parameter(model, Sets, Params, Vars, Maps)
         # CSVs gated by switch_processed_results, database by switch_results_db
         # (gating inside genesysmod_results); purge once before any db writes.

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -225,36 +225,10 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
     end
   end
 
-  #TagTimeIndependentFuel = JuMP.Containers.DenseAxisArray(zeros(length(𝓨), length(𝓕), length(𝓡)), 𝓨, 𝓕, 𝓡)
+  # A fuel that can be used/demanded but not produced is time-independent. This is
+  # derived from the data; the old hard-coded `Info == "reduced"`/`"reduced2"` fuel
+  # override list is dropped — time-independence comes from the input data instead.
   TagTimeIndependentFuel = CanFuelBeUsedOrDemanded.*(1 .- CanFuelBeProduced)
-  Info = "reduced"
-  if Info == "reduced"
-    TagTimeIndependentFuel[:,"Lignite",:] .= 1
-    TagTimeIndependentFuel[:,"Biomass",:] .= 1
-    TagTimeIndependentFuel[:,"Area_Rooftop_Residential",:] .= 1
-    TagTimeIndependentFuel[:,"Area_Rooftop_Commercial",:] .= 1
-    TagTimeIndependentFuel[:,"Hardcoal",:] .= 1
-    TagTimeIndependentFuel[:,"Nuclear",:] .= 1
-    TagTimeIndependentFuel[:,"Oil",:] .= 1
-    TagTimeIndependentFuel[:,"Air",:] .= 1
-    TagTimeIndependentFuel[:,"DAC_Dummy",:] .= 1
-    TagTimeIndependentFuel[:,"ETS",:] .= 1
-    TagTimeIndependentFuel[:,"ETS_Source",:] .= 1
-  elseif Info == "reduced2"
-    TagTimeIndependentFuel[:,"Lignite",:] .= 1
-    TagTimeIndependentFuel[:,"Biomass",:] .= 1
-    TagTimeIndependentFuel[:,"Area_Rooftop_Residential",:] .= 1
-    TagTimeIndependentFuel[:,"Area_Rooftop_Commercial",:] .= 1
-    TagTimeIndependentFuel[:,"Hardcoal",:] .= 1
-    TagTimeIndependentFuel[:,"Nuclear",:] .= 1
-    TagTimeIndependentFuel[:,"Oil",:] .= 1
-    TagTimeIndependentFuel[:,"Air",:] .= 1
-    TagTimeIndependentFuel[:,"DAC_Dummy",:] .= 1
-    TagTimeIndependentFuel[:,"ETS",:] .= 1
-    TagTimeIndependentFuel[:,"ETS_Source",:] .= 1
-    TagTimeIndependentFuel[:,"LNG",:] .= 1
-    TagTimeIndependentFuel[:,"LBG",:] .= 1
-  end
 
   IgnoreFuel = JuMP.Containers.DenseAxisArray(zeros(length(𝓨), length(𝓕), length(𝓡)), 𝓨, 𝓕, 𝓡)
   for y ∈ 𝓨 for f ∈ 𝓕 for r ∈ 𝓡

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -225,10 +225,16 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
     end
   end
 
-  # A fuel that can be used/demanded but not produced is time-independent. This is
-  # derived from the data; the old hard-coded `Info == "reduced"`/`"reduced2"` fuel
-  # override list is dropped — time-independence comes from the input data instead.
+  # A fuel that can be used/demanded but not produced is time-independent (derived
+  # base). On top of that, the per-fuel data tag Par_TagTimeIndependentFuel marks
+  # additional fuels as time-independent — replacing the old hard-coded
+  # `Info == "reduced"` override list with an input-data parameter.
   TagTimeIndependentFuel = CanFuelBeUsedOrDemanded.*(1 .- CanFuelBeProduced)
+  for f ∈ 𝓕
+    if Params.TagTimeIndependentFuel[f] == 1
+      TagTimeIndependentFuel[:,f,:] .= 1
+    end
+  end
 
   IgnoreFuel = JuMP.Containers.DenseAxisArray(zeros(length(𝓨), length(𝓕), length(𝓡)), 𝓨, 𝓕, 𝓡)
   for y ∈ 𝓨 for f ∈ 𝓕 for r ∈ 𝓡

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -1012,14 +1012,23 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
         @constraint(model, sum(Vars.AnnualTechnologyEmission[y,t,e,r] for t ∈ 𝓣) - (Switch.switch_dispatch isa NoDispatch ? 0 : DummyEmissionInfeasibility[y,e,r]) == Vars.AnnualEmissions[y,e,r],
         base_name="E6_AnnualEmissionsAccounting|$(y)|$(e)|$(r)")
 
-        @constraint(model, Vars.AnnualEmissions[y,e,r]+Params.AnnualExogenousEmission[r,e,y] <= Params.RegionalAnnualEmissionLimit[r,e,y],
-        base_name="E8_RegionalAnnualEmissionsLimit|$(y)|$(e)|$(r)")
+        # Only emit the limit constraint when a real limit is set; the 999999
+        # sentinel ("no limit") would otherwise add a toothless <= ~1e6 row that
+        # stretches the RHS range.
+        if Params.RegionalAnnualEmissionLimit[r,e,y] < 999999
+          @constraint(model, Vars.AnnualEmissions[y,e,r]+Params.AnnualExogenousEmission[r,e,y] <= Params.RegionalAnnualEmissionLimit[r,e,y],
+          base_name="E8_RegionalAnnualEmissionsLimit|$(y)|$(e)|$(r)")
+        end
       end
-      @constraint(model, sum(Vars.AnnualEmissions[y,e,r]+Params.AnnualExogenousEmission[r,e,y] for r ∈ 𝓡) <= Params.AnnualEmissionLimit[e,y],
-      base_name="E9_AnnualEmissionsLimit|$(y)|$(e)")
+      if Params.AnnualEmissionLimit[e,y] < 999999
+        @constraint(model, sum(Vars.AnnualEmissions[y,e,r]+Params.AnnualExogenousEmission[r,e,y] for r ∈ 𝓡) <= Params.AnnualEmissionLimit[e,y],
+        base_name="E9_AnnualEmissionsLimit|$(y)|$(e)")
+      end
     end
-    @constraint(model, sum(Vars.ModelPeriodEmissions[r,e] for r ∈ 𝓡) <= Params.ModelPeriodEmissionLimit[e],
-    base_name="E10_ModelPeriodEmissionsLimit|$(e)")
+    if Params.ModelPeriodEmissionLimit[e] < 999999
+      @constraint(model, sum(Vars.ModelPeriodEmissions[r,e] for r ∈ 𝓡) <= Params.ModelPeriodEmissionLimit[e],
+      base_name="E10_ModelPeriodEmissionsLimit|$(e)")
+    end
   end
 
   print("Cstr: Em. Acc. 2 : ",Dates.now()-start,"\n")
@@ -1059,16 +1068,16 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
   ################ Sectoral Emissions Accounting ##############
   start=Dates.now()
   for y ∈ 𝓨, e ∈ 𝓔, se ∈ 𝓢𝓮
-#    if Params.AnnualSectoralEmissionLimit[e,se,y] < 999999
       for r ∈ 𝓡
         @constraint(model,
         sum(Vars.AnnualTechnologyEmission[y,t,e,r] for t ∈ techs_by_sector[se]) == Vars.AnnualSectoralEmissions[y,e,se,r],
         base_name="E12_AnnualSectorEmissions|$(y)|$(e)|$(se)|$(r)")
       end
-      @constraint(model,
-      sum(Vars.AnnualSectoralEmissions[y,e,se,r] for r ∈ 𝓡 ) <= Params.AnnualSectoralEmissionLimit[e,se,y],
-      base_name="E13_AnnualSectorEmissionsLimit|$(y)|$(e)|$(se)")
-#    end
+      if Params.AnnualSectoralEmissionLimit[e,se,y] < 999999
+        @constraint(model,
+        sum(Vars.AnnualSectoralEmissions[y,e,se,r] for r ∈ 𝓡 ) <= Params.AnnualSectoralEmissionLimit[e,se,y],
+        base_name="E13_AnnualSectorEmissionsLimit|$(y)|$(e)|$(se)")
+      end
   end
 
   print("Cstr: ES: ",Dates.now()-start,"\n")

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -956,7 +956,7 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
   for y ∈ 𝓨 for (t,m) ∈ Maps.Set_Tech_MO for r ∈ 𝓡
     if CanBuildTechnology[y,t,r] > 0
       for e ∈ 𝓔
-        @constraint(model, Params.EmissionActivityRatio[r,t,m,e,y]*sum((Vars.TotalAnnualTechnologyActivityByMode[y,t,m,r]*Params.EmissionContentPerFuel[f,e]*Params.InputActivityRatio[r,t,f,m,y]) for f ∈ Maps.Tech_Fuel[t]) == Vars.AnnualTechnologyEmissionByMode[y,t,e,m,r] , base_name="E1_AnnualEmissionProductionByMode|$(y)|$(t)|$(e)|$(m)|$(r)" )
+        @constraint(model, Params.EmissionActivityRatio[r,t,m,e,y]*sum((Vars.TotalAnnualTechnologyActivityByMode[y,t,m,r]*Params.EmissionContentPerFuel[f,e]*Params.InputActivityRatio[r,t,f,m,y]) for f ∈ Maps.Tech_Fuel[t]; init=0.0) == Vars.AnnualTechnologyEmissionByMode[y,t,e,m,r] , base_name="E1_AnnualEmissionProductionByMode|$(y)|$(t)|$(e)|$(m)|$(r)" )
       end
     else
       for e ∈ 𝓔
@@ -1291,7 +1291,7 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
         end
       end
       for t ∈ Sets.Technology
-        if (Params.Tags.TagDispatchableTechnology[t] == 0 || sum(Params.OutputActivityRatio[r,t,f,m,y] for f ∈ Maps.Tech_Fuel[t] for m ∈ Maps.Tech_MO[t]) == 0 || Params.ProductionChangeCost[t,y] == 0 || Params.AvailabilityFactor[r,t,y] == 0 || Params.TotalAnnualMaxCapacity[r,t,y] == 0 || Params.TotalTechnologyModelPeriodActivityUpperLimit[r,t] == 0)
+        if (Params.Tags.TagDispatchableTechnology[t] == 0 || sum(Params.OutputActivityRatio[r,t,f,m,y] for f ∈ Maps.Tech_Fuel[t] for m ∈ Maps.Tech_MO[t]; init=0.0) == 0 || Params.ProductionChangeCost[t,y] == 0 || Params.AvailabilityFactor[r,t,y] == 0 || Params.TotalAnnualMaxCapacity[r,t,y] == 0 || Params.TotalTechnologyModelPeriodActivityUpperLimit[r,t] == 0)
           JuMP.fix(Vars.DiscountedAnnualProductionChangeCost[y,t,r], 0; force=true)
           JuMP.fix(Vars.AnnualProductionChangeCost[y,t,r], 0; force=true)
         end

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -813,6 +813,9 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
   # over a technology subset (Tags.TagTechnologyToSubsets) intersected with a
   # region subset (Tags.TagRegionToSubsets), per year. Use 999999 sentinel for
   # "no upper limit" (matches TCC1 convention); 0 lower limit is inert.
+  # Group limits only bind investment runs; in a region-restricted dispatch they
+  # can be spuriously infeasible, so skip them outside the NoDispatch path.
+  if Switch.switch_dispatch isa NoDispatch
   for (ts, techs) ∈ Params.Tags.TagTechnologyToSubsets
     techs_in_subset = intersect(techs, 𝓣)
     isempty(techs_in_subset) && continue
@@ -834,6 +837,7 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
         end
       end
     end
+  end
   end
   print("Cstr: Tot. Cap. : ",Dates.now()-start,"\n")
 
@@ -1251,13 +1255,17 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
               base_name="R1_ProductionChange|$(y)|$(𝓛[i])|$(f)|$(t)|$(r)")
             end
             if Params.Tags.TagDispatchableTechnology[t]==1 && Params.RampingUpFactor[t,y] != 0 && Params.AvailabilityFactor[r,t,y] > 0 && Params.TotalAnnualMaxCapacity[r,t,y] > 0 && Params.TotalTechnologyModelPeriodActivityUpperLimit[r,t] > 0
+              # sampled hours represent elmod_hourstep real hours apart, so scale the
+              # per-step ramp budget by that spacing (reduced-timeseries correctness).
+              ramp_hours = max(Int(Switch.elmod_hourstep), 1)
               @constraint(model,
-              Vars.ProductionUpChangeInTimeslice[y,𝓛[i],f,t,r] <= Vars.TotalCapacityAnnual[y,t,r]*Params.AvailabilityFactor[r,t,y]*Params.CapacityToActivityUnit[t]*Params.RampingUpFactor[t,y]*Params.YearSplit[𝓛[i],y],
+              Vars.ProductionUpChangeInTimeslice[y,𝓛[i],f,t,r] <= Vars.TotalCapacityAnnual[y,t,r]*Params.AvailabilityFactor[r,t,y]*Params.CapacityToActivityUnit[t]*Params.RampingUpFactor[t,y]*Params.YearSplit[𝓛[i],y]*ramp_hours,
               base_name="R2_RampingUpLimit|$(y)|$(𝓛[i])|$(f)|$(t)|$(r)")
             end
             if Params.Tags.TagDispatchableTechnology[t]==1 && Params.RampingDownFactor[t,y] != 0 && Params.AvailabilityFactor[r,t,y] > 0 && Params.TotalAnnualMaxCapacity[r,t,y] > 0 && Params.TotalTechnologyModelPeriodActivityUpperLimit[r,t] > 0
+              ramp_hours = max(Int(Switch.elmod_hourstep), 1)
               @constraint(model,
-              Vars.ProductionDownChangeInTimeslice[y,𝓛[i],f,t,r] <= Vars.TotalCapacityAnnual[y,t,r]*Params.AvailabilityFactor[r,t,y]*Params.CapacityToActivityUnit[t]*Params.RampingDownFactor[t,y]*Params.YearSplit[𝓛[i],y],
+              Vars.ProductionDownChangeInTimeslice[y,𝓛[i],f,t,r] <= Vars.TotalCapacityAnnual[y,t,r]*Params.AvailabilityFactor[r,t,y]*Params.CapacityToActivityUnit[t]*Params.RampingDownFactor[t,y]*Params.YearSplit[𝓛[i],y]*ramp_hours,
               base_name="R3_RampingDownLimit|$(y)|$(𝓛[i])|$(f)|$(t)|$(r)")
             end
           end

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -31,9 +31,9 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
   + sum(Vars.DiscountedAnnualTotalTradeCosts[y,r] for y ∈ 𝓨 for r ∈ 𝓡)
   + sum(Vars.DiscountedNewTradeCapacityCosts[y,f,r,rr] for y ∈ 𝓨 for (f,r,rr) ∈ Maps.Set_Fuel_Regions)
   + sum(Vars.DiscountedAnnualCurtailmentCost[y,f,r] for y ∈ 𝓨 for f ∈ 𝓕 for r ∈ 𝓡)
-  + sum(Vars.BaseYearBounds_TooHigh[r,t,f,y]*9999 for y ∈ 𝓨 for r ∈ 𝓡 for (t,f) ∈ Maps.Set_Tech_FuelOut)
-  + sum(Vars.BaseYearBounds_TooLow[r,t,f,y]*9999 for y ∈ 𝓨 for r ∈ 𝓡 for (t,f) ∈ Maps.Set_Tech_FuelOut)
-  + sum(Vars.HeatingSlack[r,y]*9999 for r ∈ 𝓡 for y ∈ 𝓨)
+  + (Switch.switch_base_year_bounds_debugging == 1 ? sum(Vars.BaseYearBounds_TooHigh[r,t,f,y]*1000 for y ∈ 𝓨 for r ∈ 𝓡 for (t,f) ∈ Maps.Set_Tech_FuelOut) : 0)
+  + (Switch.switch_base_year_bounds_debugging == 1 ? sum(Vars.BaseYearBounds_TooLow[r,t,f,y]*1000 for y ∈ 𝓨 for r ∈ 𝓡 for (t,f) ∈ Maps.Set_Tech_FuelOut) : 0)
+  + (Switch.switch_base_year_bounds_debugging == 1 ? sum(Vars.HeatingSlack[r,y]*1000 for r ∈ 𝓡 for y ∈ 𝓨) : 0)
   - sum(Vars.DiscountedSalvageValueTransmission[y,r] for y ∈ 𝓨 for r ∈ 𝓡)
   + (Switch.switch_dispatch isa NoDispatch ? 0 : sum(DummyEmissionInfeasibility[y,e,r] * 99999 for y ∈ 𝓨 for r ∈ 𝓡 for e ∈ 𝓔)))
   print("Cstr: Cost : ",Dates.now()-start,"\n")
@@ -1335,20 +1335,20 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
 
    ############### General BaseYear Limits && trajectories #############
    start=Dates.now()
+    # Production mode (switch_base_year_bounds_debugging == 0): slack vars don't
+    # exist, so the base-year bounds are strict. Debug mode: slack vars carry a
+    # BigM penalty in the objective so an infeasible base-year floor shows softly.
+    debug = Switch.switch_base_year_bounds_debugging == 1
     for y ∈ 𝓨 for (t,f) ∈ Maps.Set_Tech_FuelOut for r ∈ 𝓡
-        if Switch.switch_base_year_bounds_debugging == 0
-          JuMP.fix(Vars.BaseYearBounds_TooHigh[r,t,f,y], 0; force=true)
-          JuMP.fix(Vars.BaseYearBounds_TooLow[r,t,f,y], 0; force=true)
-        end
         if Params.RegionalBaseYearProduction[r,t,f,y] != 0
           @constraint(model,
-          Vars.ProductionByTechnologyAnnual[y,t,f,r] >= Params.RegionalBaseYearProduction[r,t,f,y]*(1-Settings.BaseYearSlack[f]) - Vars.BaseYearBounds_TooHigh[r,t,f,y],
+          Vars.ProductionByTechnologyAnnual[y,t,f,r] >= Params.RegionalBaseYearProduction[r,t,f,y]*(1-Settings.BaseYearSlack[f]) - (debug ? Vars.BaseYearBounds_TooHigh[r,t,f,y] : 0),
           base_name="BYB1_RegionalBaseYearProductionLowerBound|$(y)|$(r)|$(t)|$(f)")
         end
 
         if Params.RegionalBaseYearProduction[r,t,f,y] != 0
           @constraint(model,
-          Vars.ProductionByTechnologyAnnual[y,t,f,r] <= Params.RegionalBaseYearProduction[r,t,f,y] + Vars.BaseYearBounds_TooLow[r,t,f,y],
+          Vars.ProductionByTechnologyAnnual[y,t,f,r] <= Params.RegionalBaseYearProduction[r,t,f,y] + (debug ? Vars.BaseYearBounds_TooLow[r,t,f,y] : 0),
           base_name="BYB2_RegionalBaseYearProductionUpperBound|$(y)|$(r)|$(t)|$(f)")
         end
     end end end

--- a/src/genesysmod_levelizedcosts.jl
+++ b/src/genesysmod_levelizedcosts.jl
@@ -82,9 +82,13 @@ function genesysmod_levelizedcosts(model,Sets, Params, VarPar, Vars, Switch, Set
 
     CarbonPrice = JuMP.Containers.DenseAxisArray(zeros(length(Sets.Region_full),length(Sets.Emission),length(Sets.Year)), Sets.Region_full, Sets.Emission, Sets.Year)
     for r ∈ Sets.Region_full for y ∈ Sets.Year for e ∈ Sets.Emission
-        CarbonPrice[r,e,y] = (-1)*dual(constraint_by_name(model,"E8_RegionalAnnualEmissionsLimit_$(y)_CO2_$(r)"))
+        # Constraints may be absent (guarded `< 999999` in equ.jl) or name-mismatched
+        # (pipe vs underscore — pre-existing latent issue). Either way: no shadow price.
+        cref = constraint_by_name(model,"E8_RegionalAnnualEmissionsLimit_$(y)_CO2_$(r)")
+        CarbonPrice[r,e,y] = cref === nothing ? 0.0 : (-1)*dual(cref)
         if CarbonPrice[r,e,y] == 0
-            CarbonPrice[r,e,y] = (-1)*dual(constraint_by_name(model,"E9_AnnualEmissionsLimit_$(y)_CO2"))
+            cref = constraint_by_name(model,"E9_AnnualEmissionsLimit_$(y)_CO2")
+            CarbonPrice[r,e,y] = cref === nothing ? 0.0 : (-1)*dual(cref)
         end
         if CarbonPrice[r,e,y] == 0
             CarbonPrice[r,e,y] = Params.EmissionsPenalty[r,e,y]

--- a/src/genesysmod_main.jl
+++ b/src/genesysmod_main.jl
@@ -251,8 +251,10 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
         #set_optimizer_attribute(model, "Names", "no")
         set_optimizer_attribute(model, "Method", 2)
         set_optimizer_attribute(model, "BarHomogeneous", 1)
+        set_optimizer_attribute(model, "NumericFocus", 1)   # mild numeric care for ill-conditioned matrices
+        set_optimizer_attribute(model, "ScaleFlag", 2)      # aggressive geometric scaling to absorb a wide coefficient range
         set_optimizer_attribute(model, "Crossover", 0)
-        set_optimizer_attribute(model, "GURO_PAR_DUMP", 1)
+        set_optimizer_attribute(model, "GURO_PAR_DUMP", 0)
         if solver_log
             set_optimizer_attribute(model, "LogFile", joinpath(resultdir,"Run_$(elmod_nthhour)_$(today()).log"))
         end

--- a/src/genesysmod_main.jl
+++ b/src/genesysmod_main.jl
@@ -337,7 +337,15 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
             error("Model infeasible. Turn on 'switch_iis' to compute and write the iis file")
         end
 
-    elseif termination_status(model) == MOI.OPTIMAL
+    elseif primal_status(model) == MOI.FEASIBLE_POINT
+        # Write results whenever a feasible primal solution exists — not only on a
+        # certified MOI.OPTIMAL. Gurobi barrier without crossover can stop at a
+        # near-optimal "sub-optimal termination" (numerically uncertified) that is
+        # still a perfectly usable solution; the strict ==OPTIMAL gate silently
+        # dropped those (no CSV, no DB). INFEASIBLE/UNBOUNDED are handled above and
+        # have no FEASIBLE_POINT, so they still skip results.
+        termination_status(model) == MOI.OPTIMAL ||
+            @warn "Solver did not certify optimality ($(termination_status(model))); writing results from the feasible solution. For a certified-optimal solve, enable crossover."
         _tr = Dates.now()
         VarPar = genesysmod_variable_parameter(model, Sets, Params, Vars,Maps)
         println("  Results: variable_parameter : ", Dates.now()-_tr); _tr = Dates.now()

--- a/src/genesysmod_results.jl
+++ b/src/genesysmod_results.jl
@@ -235,7 +235,9 @@ function genesysmod_results(model,Sets, Params, VarPar, Vars, Switch, Settings, 
     df_residual_capacity[!,:Type] .= "ResidualCapacity"
     df_residual_capacity[!,:PathwayScenario] .= "$(Switch.emissionPathway)_$(Switch.emissionScenario)"
 
-    df_total_capacity = convert_jump_container_to_df(value.(Vars.TotalCapacityAnnual[:,tmp_techs,:]);dim_names=[:Year, :Technology, :Region])
+    # Use all technologies; a leftover `tmp_techs` slice from an earlier loop had
+    # slipped in and silently dropped techs. Per-sector subsetting happens below.
+    df_total_capacity = convert_jump_container_to_df(value.(Vars.TotalCapacityAnnual[:,:,:]);dim_names=[:Year, :Technology, :Region])
     df_total_capacity[!,:Type] .= "TotalCapacity"
     df_total_capacity[!,:PathwayScenario] .= "$(Switch.emissionPathway)_$(Switch.emissionScenario)"
 

--- a/src/genesysmod_results.jl
+++ b/src/genesysmod_results.jl
@@ -288,7 +288,10 @@ function genesysmod_results(model,Sets, Params, VarPar, Vars, Switch, Settings, 
         for e ∈ Sets.Emission, y ∈ Sets.Year
             tmp_val=0
             for r ∈ Sets.Region_full
-                value = dual(constraint_by_name(model,"E8_RegionalAnnualEmissionsLimit|$(y)|$(e)|$(r)")) * (-1) * (1 + Settings.GeneralDiscountRate[r])^(y - Sets.Year[1])
+                # E8 is now generated only when a real limit is set (`< 999999`).
+                # No constraint => no shadow price (no binding scarcity) => endogenous CO2 price = 0.
+                cref = constraint_by_name(model,"E8_RegionalAnnualEmissionsLimit|$(y)|$(e)|$(r)")
+                value = cref === nothing ? 0.0 : dual(cref) * (-1) * (1 + Settings.GeneralDiscountRate[r])^(y - Sets.Year[1])
                 push!(df_endo_emission, (; Region=r, Emission=e, Year=y, Value=value))
                 tmp_val += value
             end

--- a/src/genesysmod_timeseries_reduction.jl
+++ b/src/genesysmod_timeseries_reduction.jl
@@ -505,4 +505,12 @@ function timeseries_reduction!(Params, Sets, Switch)
         "YearSplit" => df_YearSplit, "TimeDepEfficiency" => df_TimeDepEfficiency)
     end
 
+    # Round tiny CapacityFactor values to zero. Source PV/solar timeseries carry a
+    # ~1e-6 twilight floor (numerical noise from the irradiance model) that
+    # propagates into CA3b matrix coefficients (CF * CapacityToActivityUnit ~ 3e-5)
+    # and widens the LP matrix range with no physical content. CF < 0.01 is well
+    # below model precision.
+    cf = Params.CapacityFactor.data
+    cf[(cf .> 0) .& (cf .< 0.01)] .= 0
+
 end


### PR DESCRIPTION
# 📌 Pull Request Summary

Collection of general robustness, conditioning, and correctness improvements to the model build, solve, and results pipeline.

## 🔗 Related Issue(s)

N/A


## 🛠️ Changes Introduced

#### Model formulation

- Emission-limit constraints (E8/E9/E10/E13) are only built when a real limit is set (< 999999), instead of always adding a toothless <= ~1e6 row; dual lookups that read these limits now return 0 when the constraint is absent instead of crashing on dual(nothing).
- TagTimeIndependentFuel is now read from the input data (Par_TagTimeIndependentFuel sheet, per-fuel) and applied on top of the derived base, replacing the hard-coded Info == "reduced" override list. New Params.TagTimeIndependentFuel field, threaded through dataload and both Params constructors.
- Group capacity limits (TCC3/TCC4) are only generated on the investment path (NoDispatch), avoiding spurious infeasibility in region-restricted dispatch.
- Ramping limits (R2/R3) scaled by max(elmod_hourstep, 1) so a reduced timeseries gets a correct per-step ramp budget.
- Base-year debug slack variables (BaseYearBounds_*, HeatingSlack) are only created when switch_base_year_bounds_debugging == 1; production runs get a leaner LP with no BigM penalty rows. BigM lowered 9999 → 1000.

#### Solve & conditioning

- Results are written on any feasible primal (primal_status == FEASIBLE_POINT), not only certified OPTIMAL, so crossover-free barrier solutions still produce output (with a warning when uncertified).
- Gurobi NumericFocus=1 + ScaleFlag=2 to absorb a wide constraint-coefficient range.
- Tiny CapacityFactor values (0, 0.01) rounded to 0 after timeseries reduction (drops PV twilight noise).

#### Results & I/O

- Input-data database dump now includes Params.Tags.

#### Bug fixes

- df_total_capacity used a stray tmp_techs slice that silently dropped technologies → now uses all techs.
- read_emissions (CSVResult) read the storage-capacity CSV instead of AnnualEmissions_*.csv.
- Empty-trade dummy entry used absent fuel "ETS" (left the sparse container {Any}) → now 𝓕[1].
- init=0.0 on the E1 emission sum and the ramping-cost skip sum, so techs with no fuels/modes don't error on an empty sum.


## 📋 Checklist

- [x] Code follows project conventions
- [x] Tests have been added/updated (if needed)
- [ ] Documentation has been updated (if applicable)
- [x] Relevant issues linked
- [x] NEWS.md updated
- [x] Version number increase applied (if planned for release)
- [x] Reviewers assigned
