### PR TITLE
add GroupTotalAnnualMaxNewCapacity / duckdb changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ It reads scenario data from Excel, builds a large LP, solves it
 
 - **Result CSVs** are written when `switch_processed_results = 1`. Processed
   outputs are rounded to 4 digits (GAMS parity).
-- **DuckDB results database** (`switch_results_db = 1`): all outputs go to
-  `genesysmod_results_db.duckdb` in `resultdir` — processed tables (`output_*`),
+- **DuckDB database** (`switch_results_db = 1`): one file, `genesysmod_db.duckdb`
+  in `resultdir` (results + input data merged) — processed tables (`output_*`),
   raw variables (`raw_*`), `Variable_Parameters` intermediates (`varpar_*`) and
   selected duals (`duals_*`). Every table carries a `Scenario` column
   (= `extr_str_results`): re-running a scenario first purges its rows from every
@@ -52,10 +52,10 @@ It reads scenario data from Excel, builds a large LP, solves it
 - **Run configuration** is recorded with the results: every `Switch` field is
   written to an `output_switches` table/CSV, so a run's exact setup travels with
   its outputs.
-- **Input-data database**: `switch_test_data_load = 1` dumps the fully processed
-  input parameters to `genesysmod_inputdata_db.duckdb` (one table per parameter
-  and per set, real dimension names, `Params.Tags` included) and stops before the
-  solve; `switch_dump_input_data = 1` writes the same dump and continues.
+- **Input-data dump**: `switch_test_data_load = 1` dumps the fully processed
+  input parameters into the same file as `input_*` tables (one per parameter
+  and per set, real dimension names, `Params.Tags` included) and stops before
+  the solve; `switch_dump_input_data = 1` writes the same dump and continues.
 - Raw dumps and DB tables use **real dimension names** (Region, Technology, Fuel,
   Year, …), not `x1..xN`.
 - DB handles are released at run end (`release_dbs()`, exported); a write blocked

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 Release Notes
 =============
 
+## Unreleased
+- One DuckDB file: the results database and the input-data dump database are merged
+  into a single `genesysmod_db.duckdb` (result tables `output_*`/`raw_*`/`varpar_*`/
+  `duals_*`, input dumps as `input_*` tables). Runs made before the merge are still
+  found: readers fall back to the old `genesysmod_results_db.duckdb` name.
+- New `Scripts/manage_results_db.py`: interactive manager for the results database
+  (list scenarios, rename, split into a separate file, purge, compact).
+- New group annual-addition limit `Par_GroupTotalAnnualMaxNewCap` (TCC5): caps the
+  summed annual NewCapacity of a technology subset x region subset from input data,
+  complementing the TCC3/TCC4 level limits.
+- SC2 (annual RE-additions cap) now floors at the min-capacity increment, so a
+  dataset whose capacity ceiling hugs a steeply rising exogenous minimum stays
+  feasible under switch_investLimit.
+
 ## v4.4.1
 - Emission-limit constraints (E8/E9/E10/E13) are only generated when a real limit is
   set (`< 999999`) instead of always adding a toothless `<= ~1e6` row; dual lookups

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-## Unreleased
+## v4.5.0
 - One DuckDB file: the results database and the input-data dump database are merged
   into a single `genesysmod_db.duckdb` (result tables `output_*`/`raw_*`/`varpar_*`/
   `duals_*`, input dumps as `input_*` tables). Runs made before the merge are still

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GENeSYSMOD"
 uuid = "9f3a37f9-d498-4265-a124-3ae3e9ff3acf"
-version = "4.4.1"
+version = "4.5.0"
 authors = ["Dimitri Pinel <dimitri.pinel@sintef.no>", "Lars Hellemo <lars.hellemo@sintef.no>, Konstantin Löffler <kl@wip.tu-berlin.de>"]
 
 [deps]

--- a/Scripts/manage_results_db.py
+++ b/Scripts/manage_results_db.py
@@ -1,0 +1,213 @@
+"""Interactive manager for the GENeSYS-MOD DuckDB results database.
+
+Lists the scenarios (model runs) stored in a database, and lets you
+  re[n]ame  rename a scenario (fix a mislabelled extr_str) across all tables
+  [s]plit   copy selected scenarios into a separate .duckdb (backup/archive),
+            optionally including the shared (non-scenario) tables such as the
+            input_* dump, and optionally purging them from the source (= move)
+  [p]urge   delete selected scenarios from every scenario-keyed table
+  [c]ompact rewrite the database file to reclaim disk space after purges
+  [r]efresh re-scan, [q]uit
+
+Works on any GENeSYS-MOD DuckDB: scenario-keyed tables are discovered by their
+`Scenario` column (results db AND dispatch db); tables without one (input_*,
+SET_* ...) are treated as shared.
+
+Usage:  python Scripts/manage_results_db.py [path/to/db.duckdb]
+        default: Results/genesysmod_db.duckdb (relative to the repo root)
+
+The database must not be open elsewhere (close DBeaver/Julia first; a running
+model/dispatch holds the file only briefly since the read-only fix).
+"""
+import os
+import shutil
+import sys
+import datetime
+
+import duckdb
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_DB = os.path.join(REPO, "Results", "genesysmod_db.duckdb")
+
+
+def q_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def connect(path, read_only=False):
+    try:
+        return duckdb.connect(path, read_only=read_only)
+    except duckdb.IOException as e:
+        sys.exit(f"Cannot open {path}:\n  {e}\nClose other programs holding it (DBeaver, Julia) and retry.")
+
+
+def scan(con):
+    """Return (scenario_tables, shared_tables, {scenario: total_rows})."""
+    tables = [r[0] for r in con.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema='main'").fetchall()]
+    scen_tables, shared = [], []
+    for t in tables:
+        cols = {r[0] for r in con.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = ?", [t]).fetchall()}
+        (scen_tables if "Scenario" in cols else shared).append(t)
+    counts = {}
+    for t in scen_tables:
+        for sc, n in con.execute(f"SELECT Scenario, count(*) FROM {q_ident(t)} GROUP BY Scenario").fetchall():
+            counts[sc] = counts.get(sc, 0) + n
+    return sorted(scen_tables), sorted(shared), counts
+
+
+def show(counts, scen_tables, shared):
+    print(f"\n{len(scen_tables)} scenario-keyed tables, {len(shared)} shared tables (input_*, ...)")
+    if not counts:
+        print("  -- no scenarios in this database --")
+        return []
+    scens = sorted(counts)
+    print(f"  {'#':>3}  {'scenario':40} {'rows':>12}")
+    for i, sc in enumerate(scens):
+        print(f"  {i:>3}  {sc:40} {counts[sc]:>12,}")
+    return scens
+
+
+def pick(scens, prompt):
+    raw = input(f"{prompt} (indices, comma-separated; empty = cancel): ").strip()
+    if not raw:
+        return []
+    try:
+        idx = [int(x) for x in raw.replace(" ", "").split(",")]
+        sel = [scens[i] for i in idx]
+    except (ValueError, IndexError):
+        print("  invalid selection");  return []
+    print("  selected:", ", ".join(sel))
+    return sel
+
+
+def rename(con, scen_tables, scens):
+    sel = pick(scens, "scenario to rename (exactly one)")
+    if len(sel) != 1:
+        if len(sel) > 1:
+            print("  pick exactly one")
+        return
+    old = sel[0]
+    new = input(f"new name for '{old}': ").strip()
+    if not new or new == old:
+        print("  cancelled");  return
+    if new in scens and input(f"  '{new}' already exists - MERGE '{old}' into it? [y/N]: ").strip().lower() != "y":
+        return
+    n = 0
+    for t in scen_tables:
+        res = con.execute(f"UPDATE {q_ident(t)} SET Scenario = ? WHERE Scenario = ?", [new, old]).fetchall()
+        n += res[0][0] if res else 0
+    print(f"  renamed '{old}' -> '{new}' ({n:,} rows)")
+
+
+def purge(con, scen_tables, sel):
+    for sc in sel:
+        n = 0
+        for t in scen_tables:
+            res = con.execute(f"DELETE FROM {q_ident(t)} WHERE Scenario = ?", [sc]).fetchall()
+            n += res[0][0] if res else 0
+        print(f"  purged {sc} ({n:,} rows)")
+    con.execute("CHECKPOINT")
+    print("  checkpoint done (run [c]ompact to reclaim disk space)")
+
+
+def split(con, src_path, scen_tables, shared, sel):
+    default = f"genesysmod_db_backup_{datetime.date.today():%Y%m%d}.duckdb"
+    name = input(f"target file [{os.path.join(os.path.dirname(src_path), default)}]: ").strip() \
+        or os.path.join(os.path.dirname(src_path), default)
+    if os.path.abspath(name) == os.path.abspath(src_path):
+        print("  target must differ from the source");  return
+    include_shared = input("also copy shared tables (input_* dump, ...)? [y/N]: ").strip().lower() == "y"
+    con.execute(f"ATTACH '{name}' AS tgt")
+    copied = 0
+    try:
+        for t in scen_tables:
+            has = con.execute(f"SELECT count(*) FROM {q_ident(t)} WHERE Scenario IN "
+                              f"({','.join('?' * len(sel))})", sel).fetchone()[0]
+            if has == 0:
+                continue
+            tq = q_ident(t)
+            exists = con.execute("SELECT count(*) FROM information_schema.tables "
+                                 "WHERE table_catalog='tgt' AND table_name = ?", [t]).fetchone()[0]
+            sql_sel = f"SELECT * FROM {tq} WHERE Scenario IN ({','.join('?' * len(sel))})"
+            if exists:
+                con.execute(f"DELETE FROM tgt.main.{tq} WHERE Scenario IN ({','.join('?' * len(sel))})", sel)
+                con.execute(f"INSERT INTO tgt.main.{tq} BY NAME {sql_sel}", sel)
+            else:
+                con.execute(f"CREATE TABLE tgt.main.{tq} AS {sql_sel}", sel)
+            copied += has
+        if include_shared:
+            for t in shared:
+                tq = q_ident(t)
+                con.execute(f"DROP TABLE IF EXISTS tgt.main.{tq}")
+                con.execute(f"CREATE TABLE tgt.main.{tq} AS SELECT * FROM {tq}")
+        con.execute("CHECKPOINT tgt")
+    finally:
+        con.execute("DETACH tgt")
+    print(f"  copied {copied:,} scenario rows"
+          + (" + shared tables" if include_shared else "") + f" -> {name}")
+    if input("purge the copied scenarios from the SOURCE (turn the split into a move)? [y/N]: ").strip().lower() == "y":
+        purge(con, scen_tables, sel)
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DB
+    if not os.path.isfile(path):
+        sys.exit(f"database not found: {path}")
+    print(f"database: {path}  ({os.path.getsize(path)/1e6:,.0f} MB)")
+    con = connect(path)
+    scen_tables, shared, counts = scan(con)
+    scens = show(counts, scen_tables, shared)
+    while True:
+        cmd = input("\n[s]plit  [p]urge  re[n]ame  [c]ompact  [r]efresh  [q]uit > ").strip().lower()
+        if cmd == "q":
+            break
+        elif cmd == "r":
+            scen_tables, shared, counts = scan(con)
+            scens = show(counts, scen_tables, shared)
+        elif cmd == "n":
+            rename(con, scen_tables, scens)
+            scen_tables, shared, counts = scan(con)
+            scens = show(counts, scen_tables, shared)
+        elif cmd == "s":
+            sel = pick(scens, "scenarios to split out")
+            if sel:
+                split(con, path, scen_tables, shared, sel)
+                scen_tables, shared, counts = scan(con)
+                scens = show(counts, scen_tables, shared)
+        elif cmd == "p":
+            sel = pick(scens, "scenarios to PURGE")
+            if sel and input(f"type 'purge' to delete {len(sel)} scenario(s) permanently: ").strip() == "purge":
+                purge(con, scen_tables, sel)
+                scen_tables, shared, counts = scan(con)
+                scens = show(counts, scen_tables, shared)
+        elif cmd == "c":
+            # rewrite the whole database into a fresh file, then swap it in:
+            # DuckDB CHECKPOINT does not return already-allocated blocks, so a
+            # copy-rewrite is the reliable way to shrink after purges.
+            con.close()
+            tmp = path + ".compact"
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            size0 = os.path.getsize(path)
+            c2 = duckdb.connect(tmp)
+            c2.execute(f"ATTACH '{path}' AS src (READ_ONLY)")
+            for (t,) in c2.execute("SELECT table_name FROM information_schema.tables "
+                                   "WHERE table_catalog='src' AND table_schema='main'").fetchall():
+                c2.execute(f"CREATE TABLE {q_ident(t)} AS SELECT * FROM src.main.{q_ident(t)}")
+            c2.execute("DETACH src")
+            c2.close()
+            bak = path + ".pre_compact.bak"
+            shutil.move(path, bak)
+            shutil.move(tmp, path)
+            print(f"  compacted {size0/1e6:,.0f} MB -> {os.path.getsize(path)/1e6:,.0f} MB "
+                  f"(original kept as {os.path.basename(bak)} - delete it once verified)")
+            con = connect(path)
+        else:
+            print("  ? s / p / c / r / q")
+    con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -327,6 +327,10 @@ struct Parameters <: InputClass
     # (TechSubset, RegionSubset, Year). Max defaults to 999999 (=no limit).
     GroupTotalAnnualMaxCapacity ::JuMP.Containers.DenseAxisArray
     GroupTotalAnnualMinCapacity ::JuMP.Containers.DenseAxisArray
+    # Aggregated upper limit on NewCapacity (annual capacity *additions*) summed
+    # over a technology subset x region subset, per year. 999999 = no limit.
+    # Smooths the build path of a tech group via data, no per-tech/region hardcode.
+    GroupTotalAnnualMaxNewCapacity ::JuMP.Containers.DenseAxisArray
 
     # Per-fuel time-independence tag read from Par_TagTimeIndependentFuel (Fuel, Value);
     # 1 = the fuel balance is enforced annually rather than per timeslice. Fuels not

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -798,7 +798,7 @@ run that will be read to fix some decision variables.\n
   2 (default) = GAMS behaviour, abort on hard errors.\n
 - **`switch_results_db ::Int8`** If 1 (default 0), all outputs (processed result tables,
   raw variables, VarPar intermediates) are written to a single DuckDB file
-  `genesysmod_results_db.duckdb` in the result directory — independent of the CSV
+  `genesysmod_db.duckdb` in the result directory — independent of the CSV
   switches (`switch_processed_results` gates only the CSV files). Tables are keyed by
   a `Scenario` column = `extr_str_results`: re-running a scenario first purges its rows
   from every table (so runs writing fewer tables leave no stale rows), a new scenario

--- a/src/genesysmod_dataload.jl
+++ b/src/genesysmod_dataload.jl
@@ -428,6 +428,9 @@ function read_params(in_data, Sets, Switch, Tags)
     GroupTotalAnnualMinCapacity = "Par_GroupTotalAnnualMinCapacity" ∈ XLSX.sheetnames(in_data) ?
         create_daa(in_data, "Par_GroupTotalAnnualMinCapacity", 𝓣𝓼, 𝓡𝓼, 𝓨) :
         DenseArray(zeros(length(𝓣𝓼), length(𝓡𝓼), length(𝓨)), 𝓣𝓼, 𝓡𝓼, 𝓨)
+    GroupTotalAnnualMaxNewCapacity = "Par_GroupTotalAnnualMaxNewCap" ∈ XLSX.sheetnames(in_data) ?
+        create_daa_init(in_data, "Par_GroupTotalAnnualMaxNewCap", 999999, 𝓣𝓼, 𝓡𝓼, 𝓨) :
+        DenseArray(fill(999999.0, length(𝓣𝓼), length(𝓡𝓼), length(𝓨)), 𝓣𝓼, 𝓡𝓼, 𝓨)
     # Per-fuel time-independence tag (Fuel, Value); a standard input sheet like the other tags.
     TagTimeIndependentFuel = create_daa(in_data, "Par_TagTimeIndependentFuel", 𝓕)
     TotalTechnologyAnnualActivityUpperLimit = create_daa(in_data, "Par_TotalAnnualMaxActivity", 𝓡, 𝓣, 𝓨)
@@ -542,7 +545,7 @@ function read_params(in_data, Sets, Switch, Tags)
     StorageLevelStart,MinStorageCharge,
     OperationalLifeStorage,CapitalCostStorage,ResidualStorageCapacity,TechnologyToStorage,
     TechnologyFromStorage,StorageMaxCapacity,TotalAnnualMaxCapacity, NewCapacityExpansionStop,TotalAnnualMinCapacity,
-    GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,
+    GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,GroupTotalAnnualMaxNewCapacity,
     TagTimeIndependentFuel,
     AnnualSectoralEmissionLimit,TotalAnnualMaxCapacityInvestment,
     TotalAnnualMinCapacityInvestment,TotalTechnologyAnnualActivityUpperLimit,
@@ -651,6 +654,7 @@ function get_aggregate_params(Params_Full, Sets, Sets_full)
     # be checked against the same group limits as the full model).
     GroupTotalAnnualMaxCapacity = Params_Full.GroupTotalAnnualMaxCapacity[:,:,𝓨]
     GroupTotalAnnualMinCapacity = Params_Full.GroupTotalAnnualMinCapacity[:,:,𝓨]
+    GroupTotalAnnualMaxNewCapacity = Params_Full.GroupTotalAnnualMaxNewCapacity[:,:,𝓨]
     TagTimeIndependentFuel = Params_Full.TagTimeIndependentFuel
     TotalTechnologyAnnualActivityUpperLimit = aggregate_daa(Params_Full.TotalTechnologyAnnualActivityUpperLimit, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
     TotalTechnologyAnnualActivityLowerLimit = aggregate_daa(Params_Full.TotalTechnologyAnnualActivityLowerLimit, 𝓡, 𝓡_full, Sum(), 𝓣, 𝓨)
@@ -725,7 +729,7 @@ function get_aggregate_params(Params_Full, Sets, Sets_full)
     OperationalLifeStorage,CapitalCostStorage,ResidualStorageCapacity,TechnologyToStorage,
     TechnologyFromStorage,StorageMaxCapacity,TotalAnnualMaxCapacity,
     NewCapacityExpansionStop,TotalAnnualMinCapacity,
-    GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,
+    GroupTotalAnnualMaxCapacity,GroupTotalAnnualMinCapacity,GroupTotalAnnualMaxNewCapacity,
     TagTimeIndependentFuel,
     AnnualSectoralEmissionLimit,TotalAnnualMaxCapacityInvestment,
     TotalAnnualMinCapacityInvestment,TotalTechnologyAnnualActivityUpperLimit,

--- a/src/genesysmod_db.jl
+++ b/src/genesysmod_db.jl
@@ -1,19 +1,20 @@
 """
 DuckDB result/input writers.
 
-Two database files, both living in the result directory:
+One database file, `genesysmod_db.duckdb`, living in the result directory and
+holding both the inputs and the outputs of a run:
 
-  * `genesysmod_results_db.duckdb`  — model outputs (raw variables, VarPar,
-    processed result tables). Every table carries a `Scenario` column set to
-    `extr_str_results`; writing the same scenario again overwrites exactly
-    those rows (DELETE + INSERT in one transaction), a new scenario appends.
-    `Region`/`Pathway` context columns are included so several model regions
-    or pathways can share one file.
-  * `genesysmod_inputdata_db.duckdb` — the processed input parameters written
-    by `switch_test_data_load` (one table per parameter, one `SET_*` table per
-    index set). Mirrors the former SQLite dump, now with real dimension names.
+  * model outputs (raw variables, VarPar, processed result tables). Every
+    table carries a `Scenario` column set to `extr_str_results`; writing the
+    same scenario again overwrites exactly those rows (DELETE + INSERT in one
+    transaction), a new scenario appends. `Region`/`Pathway` context columns
+    are included so several model regions or pathways can share one file.
+  * the processed input parameters written by `switch_test_data_load` /
+    `switch_dump_input_data`, prefixed `input_` — one `input_<Parameter>`
+    table per parameter, `input_SET_*` per index set, `input_<Tag>` per tag.
+    Re-dumping replaces only the `input_*` tables; result tables are untouched.
 
-Open either file with DBeaver (DuckDB driver, read-only while a run writes),
+Open the file with DBeaver (DuckDB driver, read-only while a run writes),
 DuckDB CLI, Python (`duckdb` package) or Julia.
 """
 
@@ -90,11 +91,15 @@ end
 # DuckDB plumbing
 # ---------------------------------------------------------------------------
 
-const RESULTS_DB_FILENAME = "genesysmod_results_db.duckdb"
-const INPUTDATA_DB_FILENAME = "genesysmod_inputdata_db.duckdb"
+const DB_FILENAME = "genesysmod_db.duckdb"
+# Pre-merge filename (results-only db) — used as a read fallback so dispatch
+# still finds the investment results of runs made before the merge.
+const LEGACY_RESULTS_DB_FILENAME = "genesysmod_results_db.duckdb"
 
-_results_db_path(Switch) = joinpath(Switch.resultdir[], RESULTS_DB_FILENAME)
-_inputdata_db_path(Switch) = joinpath(Switch.resultdir[], INPUTDATA_DB_FILENAME)
+_db_path(Switch) = joinpath(Switch.resultdir[], DB_FILENAME)
+# Both writers share one file since the input/results merge.
+_results_db_path(Switch) = _db_path(Switch)
+_inputdata_db_path(Switch) = _db_path(Switch)
 
 # One cached handle per database file per process. DuckDB does not allow a
 # second handle on the same file within one process (and closing a handle
@@ -111,8 +116,9 @@ end
 """
     release_dbs()
 
-Close all DuckDB handles held by this Julia process (results + input-data
-databases). Closing checkpoints the .wal into the main file and releases the
+Close all DuckDB handles held by this Julia process (the merged
+`genesysmod_db.duckdb`, dispatch db, legacy files). Closing checkpoints the
+.wal into the main file and releases the
 file lock, so the .duckdb can be opened in DBeaver etc. without ending the
 Julia session. Called automatically at the end of a model run; safe to call
 manually any time — the next write simply reopens the file.
@@ -289,7 +295,7 @@ end
 
 """
 Write the processed result tables (the same DataFrames the output_*.csv
-writers produce) into `genesysmod_results_db.duckdb`, keyed by scenario.
+writers produce) into `genesysmod_db.duckdb`, keyed by scenario.
 """
 function write_processed_results_db(tables::AbstractDict, Sets, Switch, extr_str)
     con = _db_connect(_results_db_path(Switch))
@@ -301,7 +307,7 @@ end
 
 """
 Write raw model variables, the VarPar intermediates and Demand/RateOfDemand
-into `genesysmod_results_db.duckdb` (tables prefixed raw_/varpar_), keyed by
+into `genesysmod_db.duckdb` (tables prefixed raw_/varpar_), keyed by
 scenario like the processed tables.
 """
 function write_raw_results_db(model, VarPar, Params, Sets, Switch, extr_str)
@@ -335,7 +341,7 @@ end
 """
 Write a duals frame — the (constraint-name, dual-value) DataFrame produced by
 `genesysmod_getspecifiedduals` / `genesysmod_getdualsbyname` — into
-`genesysmod_results_db.duckdb` as `duals_<label>`, keyed by scenario like the
+`genesysmod_db.duckdb` as `duals_<label>`, keyed by scenario like the
 other result tables (columns renamed to `Constraint`/`Dual`). Empty frame is a
 no-op; wrapped in `_db_attempt` so a locked file never aborts the run.
 """
@@ -354,25 +360,21 @@ end
 # ---------------------------------------------------------------------------
 
 """
-Dump the processed input data to `genesysmod_inputdata_db.duckdb` — one table
-per parameter (real dimension names), one `SET_*` table per index set.
-Successor of the former SQLite dump; the file is recreated on every dump.
+Dump the processed input data into `genesysmod_db.duckdb` (shared with the
+result tables) — one `input_<Parameter>` table per parameter (real dimension
+names), one `input_SET_*` table per index set, `input_<Tag>` per tag.
+Re-dumping drops and rewrites ONLY the `input_*` tables; the result tables in
+the same file are never touched.
 """
 function dump_inputs_db(case, switch::Switch)
     Params = case["Params"]
     Sets   = case["Sets"]
     dbpath = _inputdata_db_path(switch)
-    # Recreate content. The file cannot be deleted if this process already
-    # holds the handle, so drop all existing tables through it instead.
-    if haskey(_DB_HANDLES, abspath(dbpath))
-        con = _db_connect(dbpath)
-        for t in DataFrame(DBInterface.execute(con,
-                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'")).table_name
-            DBInterface.execute(con, "DROP TABLE IF EXISTS $(_quote_ident(t))")
-        end
-    else
-        isfile(dbpath) && rm(dbpath)
-        con = _db_connect(dbpath)
+    con = _db_connect(dbpath)
+    for t in DataFrame(DBInterface.execute(con,
+            "SELECT table_name FROM information_schema.tables " *
+            "WHERE table_schema = 'main' AND table_name LIKE 'input\\_%' ESCAPE '\\'")).table_name
+        DBInterface.execute(con, "DROP TABLE IF EXISTS $(_quote_ident(t))")
     end
     ntables = 0
     for field in fieldnames(typeof(Params))
@@ -383,7 +385,7 @@ function dump_inputs_db(case, switch::Switch)
             isempty(df) && continue
             reg = "df_in"
             DuckDB.register_data_frame(con, df, reg)
-            DBInterface.execute(con, "CREATE TABLE $(_quote_ident(field)) AS SELECT * FROM $(_quote_ident(reg))")
+            DBInterface.execute(con, "CREATE TABLE $(_quote_ident("input_" * string(field))) AS SELECT * FROM $(_quote_ident(reg))")
             DuckDB.unregister_data_frame(con, reg)
             ntables += 1
         catch e
@@ -409,7 +411,7 @@ function dump_inputs_db(case, switch::Switch)
                 isempty(df) && continue
                 reg = "df_tag"
                 DuckDB.register_data_frame(con, df, reg)
-                DBInterface.execute(con, "CREATE TABLE $(_quote_ident(string(tf))) AS SELECT * FROM $(_quote_ident(reg))")
+                DBInterface.execute(con, "CREATE TABLE $(_quote_ident("input_" * string(tf))) AS SELECT * FROM $(_quote_ident(reg))")
                 DuckDB.unregister_data_frame(con, reg)
                 ntables += 1
             catch e
@@ -423,7 +425,7 @@ function dump_inputs_db(case, switch::Switch)
         try
             reg = "df_set"
             DuckDB.register_data_frame(con, DataFrame(value = collect(s)), reg)
-            DBInterface.execute(con, "CREATE TABLE $(_quote_ident("SET_" * string(field))) AS SELECT * FROM $(_quote_ident(reg))")
+            DBInterface.execute(con, "CREATE TABLE $(_quote_ident("input_SET_" * string(field))) AS SELECT * FROM $(_quote_ident(reg))")
             DuckDB.unregister_data_frame(con, reg)
             ntables += 1
         catch e

--- a/src/genesysmod_equ.jl
+++ b/src/genesysmod_equ.jl
@@ -647,8 +647,16 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
           for r ∈ 𝓡
             for t ∈ intersect(Sets.Technology, Params.Tags.TagTechnologyToSubsets["Renewables"])
                 if 𝓨[i] > 2025
+                    # SC2 must never cap below the new-build needed to stay on the
+                    # TotalAnnualMinCapacity path: a tight TotalAnnualMaxCapacity
+                    # (max ~ min) makes f*max alone starve a steep exogenous min ->
+                    # infeasible under switch_investLimit. min_inc is a constant
+                    # from input params (min, residual); keeps the model linear.
+                    rr_y  = max(0.0, Params.TotalAnnualMinCapacity[r,t,𝓨[i]]   - Params.ResidualCapacity[r,t,𝓨[i]])
+                    rr_ym = max(0.0, Params.TotalAnnualMinCapacity[r,t,𝓨[i-1]] - Params.ResidualCapacity[r,t,𝓨[i-1]])
+                    min_inc = max(0.0, rr_y - rr_ym)
                     @constraint(model,
-                    Vars.NewCapacity[𝓨[i],t,r] <= YearlyDifferenceMultiplier(𝓨[i-1],Sets)*Settings.NewRESCapacity*Params.TotalAnnualMaxCapacity[r,t,𝓨[i]],
+                    Vars.NewCapacity[𝓨[i],t,r] <= max(YearlyDifferenceMultiplier(𝓨[i-1],Sets)*Settings.NewRESCapacity*Params.TotalAnnualMaxCapacity[r,t,𝓨[i]], min_inc),
                     base_name="SC2_LimitAnnualCapacityAdditions|$(𝓨[i])|$(r)|$(t)")
                 end
             end
@@ -834,6 +842,15 @@ function genesysmod_equ(model,Sets,Params, Vars,Emp_Sets,Settings,Switch, Maps; 
             sum(Vars.TotalCapacityAnnual[y,t,r] for t ∈ techs_in_subset for r ∈ regs_in_subset)
               <= Params.GroupTotalAnnualMaxCapacity[ts,rs,y],
             base_name="TCC3_GroupMaxCapacityConstraint|$(y)|$(ts)|$(rs)")
+        end
+        # TCC5: aggregated upper limit on NewCapacity (annual additions) summed over
+        # the same subset x region subset -> smooths a tech group's build path
+        # from data, no per-tech/region hardcode. 999999 = no limit.
+        if Params.GroupTotalAnnualMaxNewCapacity[ts,rs,y] < 999999
+          @constraint(model,
+            sum(Vars.NewCapacity[y,t,r] for t ∈ techs_in_subset for r ∈ regs_in_subset)
+              <= Params.GroupTotalAnnualMaxNewCapacity[ts,rs,y],
+            base_name="TCC5_GroupMaxNewCapacityConstraint|$(y)|$(ts)|$(rs)")
         end
         if Params.GroupTotalAnnualMinCapacity[ts,rs,y] > 0
           @constraint(model,

--- a/src/genesysmod_main.jl
+++ b/src/genesysmod_main.jl
@@ -223,7 +223,7 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
     switch = case["Switch"]
 
     # switch_test_data_load: dump the processed input parameters to DuckDB
-    # (genesysmod_inputdata_db.duckdb) for inspection, then stop before solver
+    # (input_* tables in genesysmod_db.duckdb) for inspection, then stop before solver
     # setup / optimize! (mirrors the GAMS switch_test_data_load behaviour).
     # The data in case["Params"] here is post-interpolation/aggregation, so
     # this verifies the full read + process.
@@ -235,7 +235,7 @@ function genesysmod(;elmod_daystep, elmod_hourstep, solver, DNLPsolver, year=201
     end
 
     # switch_dump_input_data: same input dump as switch_test_data_load
-    # (genesysmod_inputdata_db.duckdb), but the run continues into the solve.
+    # (input_* tables in genesysmod_db.duckdb), but the run continues into the solve.
     if switch_dump_input_data == 1
         _db_attempt(() -> dump_inputs_db(case, switch), "input data dump")
     end

--- a/src/genesysmod_results_raw.jl
+++ b/src/genesysmod_results_raw.jl
@@ -136,4 +136,4 @@ function genesysmod_getdualsbyname(model,Switch,extr_str, constr_name)
 end
 
 # The input-data dump moved to DuckDB: see dump_inputs_db in genesysmod_db.jl
-# (writes genesysmod_inputdata_db.duckdb with real dimension names).
+# (writes input_* tables into genesysmod_db.duckdb with real dimension names).


### PR DESCRIPTION
# 📌 Pull Request Summary

Adds Par_GroupTotalAnnualMaxNewCapacity, improves duckdb functionalities.

## 🔗 Related Issue(s)

N/A

## 🛠️ Changes Introduced

- Addition of Par_GroupTotalAnnualMaxNewCapacity, limiting annual gross additions of a flexible region/technology group. Also adds an equation (TCC5).
- Fix for equation SC2, where the formulation could potentially lead to infeasibilities in case of unfortunate parameter combinations.
- Improvements for duckdb:
1. moved duckdb files from two separate ones to one single file (everything from one run is contained in one singular file)
2. improved writing/reading behaviour so that the db file is unlocked as much as possible
3. incusion of a db manipulation script in "Scripts" that allows for renaming/splitting/removing of runs in the db file.

## 📋 Checklist

- [x] Code follows project conventions
- [ ] Tests have been added/updated (if needed)
- [ ] Documentation has been updated (if applicable)
- [x] Relevant issues linked
- [x] NEWS.md updated
- [x] Version number increase applied (if planned for release)
- [x] Reviewers assigned
